### PR TITLE
Use loadable-components

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "emotion": "^9.0.2",
+    "loadable-components": "^1.1.1",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-router-dom": "^4.2.2"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,8 +5,7 @@ import {
   Link
 } from 'react-router-dom'
 
-import Home from './components/05_pages/Home/Home';
-import Permissions from './components/05_pages/Permissions/Permissions';
+import { Home, Permissions } from './components';
 
 import normalize from './styles/normalize'; // eslint-disable-line no-unused-vars
 import base from './styles/base'; // eslint-disable-line no-unused-vars

--- a/src/components.js
+++ b/src/components.js
@@ -1,0 +1,6 @@
+import loadable from 'loadable-components';
+
+const Home = loadable(() => import('./components/05_pages/Home/Home'));
+const Permissions = loadable(() => import('./components/05_pages/Permissions/Permissions'));
+
+export { Home, Permissions }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4287,6 +4287,12 @@ load-json-file@^2.0.0:
     pify "^2.0.0"
     strip-bom "^3.0.0"
 
+loadable-components@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/loadable-components/-/loadable-components-1.1.1.tgz#aed1f79ab15579aeab4de6563864e3ee8dcd07a2"
+  dependencies:
+    babel-plugin-syntax-dynamic-import "^6.18.0"
+
 loader-fs-cache@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/loader-fs-cache/-/loader-fs-cache-1.0.1.tgz#56e0bf08bd9708b26a765b68509840c8dec9fdbc"


### PR DESCRIPTION
- use `loadable-components`
- don't send down parts of the app that we don't need.
- currently only on entire page components, but can probably break this up further.