### PR TITLE
Allow setting a success message

### DIFF
--- a/src/actions/application.js
+++ b/src/actions/application.js
@@ -6,12 +6,21 @@ import {
 } from 'react-redux-loading-bar';
 import api from '../utils/api/api';
 
-export const SET_ERROR = 'SET_ERROR';
-export const setError = error => ({
-  type: SET_ERROR,
+export const SET_MESSAGE = 'SET_MESSAGE';
+export const MESSAGE_ERROR = 'MESSAGE_ERROR';
+export const MESSAGE_SUCCESS = 'MESSAGE_SUCCESS';
+
+export const setMessage = (message, type = MESSAGE_ERROR) => ({
+  type: SET_MESSAGE,
   payload: {
-    error,
+    message,
+    type,
   },
+});
+
+export const CLEAR_MESSAGE = 'CLEAR_MESSAGE';
+export const clearMessage = () => ({
+  type: CLEAR_MESSAGE,
 });
 
 export const MENU_REQUESTED = 'MENU_REQUESTED';
@@ -33,7 +42,7 @@ function* loadMenu() {
       },
     });
   } catch (error) {
-    yield put(setError(error));
+    yield put(setMessage(error.toString()));
   } finally {
     yield put(hideLoading());
   }

--- a/src/components/02_atoms/Error/Error.js
+++ b/src/components/02_atoms/Error/Error.js
@@ -1,5 +1,0 @@
-import React from 'react';
-
-const Error = () => <div>Error during loading</div>;
-
-export default Error;

--- a/src/components/02_atoms/Message/Message.js
+++ b/src/components/02_atoms/Message/Message.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { string, oneOf } from 'prop-types';
+import { MESSAGE_ERROR, MESSAGE_SUCCESS } from '../../../actions/application';
+
+const typeMap = {
+  [MESSAGE_ERROR]: 'error',
+  [MESSAGE_SUCCESS]: 'success',
+};
+
+const Message = ({ message, type }) => (
+  <div className={`message message--${typeMap[type]}`}>
+    {message}
+  </div>
+);
+
+Message.propTypes = {
+  message: string.isRequired,
+  type: oneOf([MESSAGE_ERROR, MESSAGE_SUCCESS]).isRequired,
+};
+
+export default Message;

--- a/src/components/02_atoms/Message/Message.js
+++ b/src/components/02_atoms/Message/Message.js
@@ -8,9 +8,7 @@ const typeMap = {
 };
 
 const Message = ({ message, type }) => (
-  <div className={`message message--${typeMap[type]}`}>
-    {message}
-  </div>
+  <div className={`message message--${typeMap[type]}`}>{message}</div>
 );
 
 Message.propTypes = {

--- a/src/components/05_pages/Permissions/Permissions.js
+++ b/src/components/05_pages/Permissions/Permissions.js
@@ -5,7 +5,12 @@ import makeCancelable from 'makecancelable';
 import { Markup } from 'interweave';
 import { css } from 'emotion';
 
-import { setMessage, clearMessage, MESSAGE_SUCCESS, MESSAGE_ERROR } from '../../../actions/application';
+import {
+  setMessage,
+  clearMessage,
+  MESSAGE_SUCCESS,
+  MESSAGE_ERROR,
+} from '../../../actions/application';
 import Loading from '../../02_atoms/Loading/Loading';
 import { Table, TBody, THead } from '../../01_subatomics/Table/Table';
 import Message from '../../02_atoms/Message/Message';

--- a/src/components/05_pages/Permissions/Permissions.js
+++ b/src/components/05_pages/Permissions/Permissions.js
@@ -1,15 +1,19 @@
 import React, { Component, Fragment } from 'react';
-import { string, shape } from 'prop-types';
+import { connect } from 'react-redux';
+import { string, shape, func } from 'prop-types';
 import makeCancelable from 'makecancelable';
 import { Markup } from 'interweave';
 import { css } from 'emotion';
 
+import { setMessage, clearMessage, MESSAGE_SUCCESS, MESSAGE_ERROR } from '../../../actions/application';
 import Loading from '../../02_atoms/Loading/Loading';
 import { Table, TBody, THead } from '../../01_subatomics/Table/Table';
-import Error from '../../02_atoms/Error/Error';
+import Message from '../../02_atoms/Message/Message';
 
 const Permissions = class Permissions extends Component {
   static propTypes = {
+    setMessage: func.isRequired,
+    clearMessage: func.isRequired,
     match: shape({
       params: shape({
         role: string,
@@ -33,6 +37,7 @@ const Permissions = class Permissions extends Component {
       changedRoles: [...new Set(prevState.changedRoles).add(roleName).values()],
       roles: this.togglePermission(permission, roleName, prevState.roles),
     }));
+    this.props.clearMessage();
   };
   fetchData = () =>
     makeCancelable(
@@ -194,7 +199,12 @@ const Permissions = class Permissions extends Component {
                   },
                   method: 'PATCH',
                 },
-              ),
+              ).then(() => {
+                this.props.setMessage(
+                  'Changes have been saved',
+                  MESSAGE_SUCCESS,
+                );
+              }),
             ),
         ).then(() => {
           this.cancelFetch = this.fetchData();
@@ -203,7 +213,10 @@ const Permissions = class Permissions extends Component {
   };
   render() {
     if (this.state.err) {
-      return <Error />;
+      // @todo should we use React error boundaries?
+      return (
+        <Message type={MESSAGE_ERROR} message="Error while loading page." />
+      );
     } else if (!this.state.loaded) {
       return <Loading />;
     }
@@ -246,4 +259,4 @@ const Permissions = class Permissions extends Component {
   }
 };
 
-export default Permissions;
+export default connect(null, { setMessage, clearMessage })(Permissions);

--- a/src/components/05_pages/Roles/Roles.js
+++ b/src/components/05_pages/Roles/Roles.js
@@ -2,9 +2,10 @@ import React, { Component } from 'react';
 import makeCancelable from 'makecancelable';
 import { Link } from 'react-router-dom';
 
+import { MESSAGE_ERROR } from '../../../actions/application';
 import Loading from '../../02_atoms/Loading/Loading';
 import { Table, TBody, THead } from '../../01_subatomics/Table/Table';
-import Error from '../../02_atoms/Error/Error';
+import Message from '../../02_atoms/Message/Message';
 
 const Roles = class Roles extends Component {
   state = {
@@ -45,7 +46,7 @@ const Roles = class Roles extends Component {
     }));
   render() {
     if (this.state.err) {
-      return <Error />;
+      return <Message message="Error loading roles" type={MESSAGE_ERROR} />;
     } else if (!this.state.loaded) {
       return <Loading />;
     }

--- a/src/components/06_wrappers/Default/Default.js
+++ b/src/components/06_wrappers/Default/Default.js
@@ -6,7 +6,7 @@ import { css } from 'emotion';
 import { scaleRotate as Menu } from 'react-burger-menu';
 import { Link } from 'react-router-dom';
 import { requestMenu } from '../../../actions/application';
-import Error from '../../02_atoms/Error/Error';
+import Message from '../../02_atoms/Message/Message';
 
 let styles;
 
@@ -53,8 +53,8 @@ class Default extends React.Component {
 
       <main className={styles.main} id={styles.main}>
         <LoadingBar />
-        {this.props.error && <Error />}
-        {!this.props.error && this.props.children}
+        {this.props.message && <Message {...this.props.message} />}
+        {this.props.children}
       </main>
     </div>
   );
@@ -114,7 +114,10 @@ styles = {
 
 Default.propTypes = {
   children: node.isRequired,
-  error: string,
+  message: shape({
+    message: string,
+    type: string,
+  }),
   menuLinks: arrayOf(
     shape({
       subtree: arrayOf(
@@ -135,11 +138,11 @@ Default.propTypes = {
 };
 
 Default.defaultProps = {
-  error: null,
+  message: null,
 };
 
 const mapStateToProps = state => ({
-  error: state.application.error || null,
+  message: state.application.message || null,
   menuLinks: state.application.menuLinks || {},
 });
 

--- a/src/reducers/application.js
+++ b/src/reducers/application.js
@@ -1,16 +1,33 @@
-import { SET_ERROR, MENU_LOADED } from '../actions/application';
+import { SET_MESSAGE, CLEAR_MESSAGE, MENU_LOADED } from '../actions/application';
+import { LOCATION_CHANGE } from 'react-router-redux';
 
 const initialState = {
-  error: null,
+  message: null,
   menuLinks: [],
 };
 
 export default (state = initialState, action) => {
   switch (action.type) {
-    case SET_ERROR: {
+    case SET_MESSAGE: {
       return {
         ...state,
-        error: action.payload.error,
+        message: {
+          message: action.payload.message,
+          type: action.payload.type,
+        },
+      };
+    }
+    case CLEAR_MESSAGE: {
+      return {
+        ...state,
+        message: null,
+      };
+    }
+    case LOCATION_CHANGE: {
+      // Clear messages on every location change.
+      return {
+        ...state,
+        message: null,
       };
     }
     case MENU_LOADED: {

--- a/src/reducers/application.js
+++ b/src/reducers/application.js
@@ -1,5 +1,9 @@
-import { SET_MESSAGE, CLEAR_MESSAGE, MENU_LOADED } from '../actions/application';
 import { LOCATION_CHANGE } from 'react-router-redux';
+import {
+  SET_MESSAGE,
+  CLEAR_MESSAGE,
+  MENU_LOADED,
+} from '../actions/application';
 
 const initialState = {
   message: null,


### PR DESCRIPTION
I converted the current error property from the state to a more generic message which allows specifying type for the message.

Few open questions:
- How do we want to handle transporting the message type for the component? Currently it uses the variable from the actions but it didn't feel like the best approach.

- There was few instances where the old Error component was rendered directly. Should we use React error boundaries instead for handling render time errors that are blocking further rendering?

- Do we want to support multiple messages at the same time?