### PR TITLE
Update requirements regarding SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ This is an admin UI for Drupal, built with JavaScript and based on [create-react
 
 - PHP 5.5.9 or greater
 - PHP's pdo_sqlite extension installed. You can use `php -m` to check.
+- SQLite 3 CLI package
+  * For ubuntu users, `sudo apt install sqlite3`. You can use `sqlite3 --version` to check that the CLI is available.
 
 ### Steps
 


### PR DESCRIPTION
Drush depends on the SQLite3 CLI during the install process, so we should probably mention it in the requirements.