### PR TITLE
Add configuration option to disable redirecting routes.

### DIFF
--- a/admin_ui_support/admin_ui_support.links.menu.yml
+++ b/admin_ui_support/admin_ui_support.links.menu.yml
@@ -1,7 +1,7 @@
 admin_ui_support.admin_ui_support_settings:
-  title: 'JS Drupal App'
+  title: 'Decoupled Administration Interface'
   route_name: admin_ui_support.admin_ui_support_settings
-  description: 'JS Drupal App integration settings'
+  description: 'Decoupled administration interface integration settings'
   parent: system.admin_config_system
   weight: 99
 

--- a/admin_ui_support/admin_ui_support.links.menu.yml
+++ b/admin_ui_support/admin_ui_support.links.menu.yml
@@ -1,0 +1,7 @@
+admin_ui_support.admin_ui_support_settings:
+  title: 'JS Drupal App'
+  route_name: admin_ui_support.admin_ui_support_settings
+  description: 'JS Drupal App integration settings'
+  parent: system.admin_config_system
+  weight: 99
+

--- a/admin_ui_support/admin_ui_support.routing.yml
+++ b/admin_ui_support/admin_ui_support.routing.yml
@@ -1,3 +1,4 @@
+# Routes controlled by the React App.
 admin_ui_support.user.permissions:
   path: '/vfancy/admin/people/permissions'
   defaults:
@@ -32,3 +33,14 @@ admin_ui_support.dblog_types:
   requirements:
       _permission: 'access site reports'
       _format: 'json'
+
+# Routes for configuration.
+admin_ui_support.admin_ui_support_settings:
+  path: '/admin/config/admin_ui_support/settings'
+  defaults:
+    _form: '\Drupal\admin_ui_support\Form\SettingsForm'
+    _title: 'JS Drupal Settings'
+  requirements:
+    _permission: 'administer site configuration'
+  options:
+    _admin_route: TRUE

--- a/admin_ui_support/admin_ui_support.routing.yml
+++ b/admin_ui_support/admin_ui_support.routing.yml
@@ -36,7 +36,7 @@ admin_ui_support.dblog_types:
 
 # Routes for configuration.
 admin_ui_support.admin_ui_support_settings:
-  path: '/admin/config/admin_ui_support/settings'
+  path: '/admin/config/system/admin-ui-support'
   defaults:
     _form: '\Drupal\admin_ui_support\Form\SettingsForm'
     _title: 'Decoupled Administration Interface'

--- a/admin_ui_support/admin_ui_support.routing.yml
+++ b/admin_ui_support/admin_ui_support.routing.yml
@@ -39,7 +39,7 @@ admin_ui_support.admin_ui_support_settings:
   path: '/admin/config/admin_ui_support/settings'
   defaults:
     _form: '\Drupal\admin_ui_support\Form\SettingsForm'
-    _title: 'JS Drupal Settings'
+    _title: 'Decoupled Administration Interface'
   requirements:
     _permission: 'administer site configuration'
   options:

--- a/admin_ui_support/admin_ui_support.services.yml
+++ b/admin_ui_support/admin_ui_support.services.yml
@@ -16,3 +16,4 @@ services:
     class: Drupal\admin_ui_support\Routing\RouteSubscriber
     tags:
       - { name: event_subscriber }
+    arguments: ['@config.factory']

--- a/admin_ui_support/config/install/admin_ui_support.settings.yml
+++ b/admin_ui_support/config/install/admin_ui_support.settings.yml
@@ -1,0 +1,1 @@
+redirect_related_routes: TRUE

--- a/admin_ui_support/config/schema/admin_ui_support.schema.yml
+++ b/admin_ui_support/config/schema/admin_ui_support.schema.yml
@@ -1,0 +1,7 @@
+admin_ui_support.settings:
+  type: config_object
+  label: 'Admin UI Support Settings'
+  mapping:
+    redirect_related_routes:
+      type: boolean
+      label: 'Redirect routes'

--- a/admin_ui_support/src/Form/SettingsForm.php
+++ b/admin_ui_support/src/Form/SettingsForm.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Drupal\admin_ui_support\Form;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Routing\RouteBuilderInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Settings form for JS Drupal App integration.
+ */
+class SettingsForm extends ConfigFormBase {
+
+  /**
+   * The router rebuilder.
+   *
+   * @var \Drupal\Core\Routing\RouteBuilderInterface
+   */
+  protected $routerRebuilder;
+
+  /**
+   * Constructs a \Drupal\system\ConfigFormBase object.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The factory for configuration objects.
+   * @param \Drupal\Core\Routing\RouteBuilderInterface $route_rebuilder
+   *   The route rebuilder.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, RouteBuilderInterface $route_rebuilder) {
+    parent::__construct($config_factory);
+    $this->routerRebuilder = $route_rebuilder;
+
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('router.builder')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'admin_ui_support.settings',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'admin_ui_support_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('admin_ui_support.settings');
+    $form['redirect_related_routes'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Redirect related routes'),
+      '#description' => $this->t('If checked routes that overridden by the App will yada yada'),
+      '#default_value' => $config->get('redirect_related_routes'),
+    ];
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    parent::submitForm($form, $form_state);
+
+    $redirect_related_routes = $form_state->getValue('redirect_related_routes');
+    if ($this->config('admin_ui_support.settings')->get('redirect_related_routes') !== $redirect_related_routes) {
+      $this->config('admin_ui_support.settings')
+        ->set('redirect_related_routes', $redirect_related_routes)
+        ->save();
+      $this->routerRebuilder->rebuild();
+    }
+
+  }
+
+}

--- a/admin_ui_support/src/Form/SettingsForm.php
+++ b/admin_ui_support/src/Form/SettingsForm.php
@@ -85,7 +85,7 @@ class SettingsForm extends ConfigFormBase {
       $this->config('admin_ui_support.settings')
         ->set('redirect_related_routes', $redirect_related_routes)
         ->save();
-      $this->routerRebuilder->rebuild();
+      $this->routerRebuilder->setRebuildNeeded();
     }
 
   }

--- a/admin_ui_support/src/Form/SettingsForm.php
+++ b/admin_ui_support/src/Form/SettingsForm.php
@@ -67,8 +67,8 @@ class SettingsForm extends ConfigFormBase {
     $config = $this->config('admin_ui_support.settings');
     $form['redirect_related_routes'] = [
       '#type' => 'checkbox',
-      '#title' => $this->t('Redirect related routes'),
-      '#description' => $this->t('If checked routes that overridden by the App will yada yada'),
+      '#title' => $this->t('Use new administrative UI when available'),
+      '#description' => $this->t('When checked, routes that have new administrative UI available will be rendered using the new decoupled JavaScript client.'),
       '#default_value' => $config->get('redirect_related_routes'),
     ];
     return parent::buildForm($form, $form_state);

--- a/admin_ui_support/src/Routing/RouteSubscriber.php
+++ b/admin_ui_support/src/Routing/RouteSubscriber.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\admin_ui_support\Routing;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Routing\RouteSubscriberBase;
 use Drupal\Core\Routing\RoutingEvents;
 use Symfony\Component\Routing\RouteCollection;
@@ -12,9 +13,26 @@ use Symfony\Component\Routing\RouteCollection;
 class RouteSubscriber extends RouteSubscriberBase {
 
   /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * RouteSubscriber constructor.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory) {
+    $this->configFactory = $config_factory;
+  }
+
+  /**
    * {@inheritdoc}
    */
   protected function alterRoutes(RouteCollection $collection) {
+    if (!$this->configFactory->get('admin_ui_support.settings')->get('redirect_related_routes')) {
+      return;
+    }
     // Find all additional routes that this module should take over by checking
     // the '_admin_related_route' route option.
     foreach ($collection->getIterator() as $override_route_name => $route) {

--- a/admin_ui_support/tests/src/Functional/RedirectRoutesTest.php
+++ b/admin_ui_support/tests/src/Functional/RedirectRoutesTest.php
@@ -18,7 +18,10 @@ class RedirectRoutesTest extends BrowserTestBase {
    */
   protected function setUp() {
     parent::setUp();
-    $this->drupalLogin($this->createUser(['administer permissions']));
+    $this->drupalLogin($this->createUser([
+      'administer permissions',
+      'administer site configuration',
+    ]));
   }
 
   /**
@@ -28,6 +31,7 @@ class RedirectRoutesTest extends BrowserTestBase {
    * @see \Drupal\admin_ui_support\Controller\DefaultController::getAppRoute()
    *
    * @throws \Behat\Mink\Exception\ResponseTextException
+   * @throws \Behat\Mink\Exception\ExpectationException
    */
   public function testRouteRedirect() {
     $paths = [
@@ -42,11 +46,11 @@ class RedirectRoutesTest extends BrowserTestBase {
       $this->assertSession()->pageTextNotContains($text);
     }
 
+    $this->drupalGet('admin/config/admin_ui_support/settings');
+    $this->assertSession()->checkboxChecked('redirect_related_routes');
+    $this->drupalPostForm('admin/config/admin_ui_support/settings', ['redirect_related_routes' => 0], 'Save configuration');
 
-    \Drupal::configFactory()->getEditable('admin_ui_support.settings')->set('redirect_related_routes', FALSE)->save();
-    \Drupal::service('router.builder')->rebuild();
-
-    // After the config is updated the paths should go to the default page.
+    // After the setting is updated the paths should go to the default page.
     foreach ($paths as $path => $text) {
       $this->drupalGet($path);
       $this->assertSession()->pageTextContains($text);

--- a/admin_ui_support/tests/src/Functional/RedirectRoutesTest.php
+++ b/admin_ui_support/tests/src/Functional/RedirectRoutesTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Drupal\Tests\admin_ui_support\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Tests redirects of routes.
+ *
+ * @group admin_ui_support
+ */
+class RedirectRoutesTest extends BrowserTestBase {
+
+  public static $modules = ['user', 'admin_ui_support'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+    $this->drupalLogin($this->createUser(['administer permissions']));
+  }
+
+  /**
+   * Tests if routes are redirect based on config setting.
+   *
+   * @see \Drupal\admin_ui_support\Routing\RouteSubscriber::alterRoutes()
+   * @see \Drupal\admin_ui_support\Controller\DefaultController::getAppRoute()
+   *
+   * @throws \Behat\Mink\Exception\ResponseTextException
+   */
+  public function testRouteRedirect() {
+    $paths = [
+      'admin/people/permissions' => 'Permissions',
+      'admin/people/roles' => 'Roles',
+    ];
+
+    // When the module is first enabled these paths will redirect an empty page
+    // because the React App is available for testing.
+    foreach ($paths as $path => $text) {
+      $this->drupalGet($path);
+      $this->assertSession()->pageTextNotContains($text);
+    }
+
+
+    \Drupal::configFactory()->getEditable('admin_ui_support.settings')->set('redirect_related_routes', FALSE)->save();
+    \Drupal::service('router.builder')->rebuild();
+
+    // After the config is updated the paths should go to the default page.
+    foreach ($paths as $path => $text) {
+      $this->drupalGet($path);
+      $this->assertSession()->pageTextContains($text);
+    }
+  }
+
+}


### PR DESCRIPTION
If you are using the React totally separately from the Drupal site you may want to disable redirecting paths from Drupal to the app.

Provides a new form at `/admin/config/admin_ui_support/settings` to enable/disable redirecting.  When the module is first enabled it will redirect.