### PR TITLE
Remove cross bundle collections for entity types that don't support bundles

### DIFF
--- a/admin_ui_support/modules/jsonapi_support/src/ResourceType/ResourceTypeRepository.php
+++ b/admin_ui_support/modules/jsonapi_support/src/ResourceType/ResourceTypeRepository.php
@@ -30,12 +30,14 @@ class ResourceTypeRepository extends JsonApiResourceTypeRepository {
       $this->all = parent::all();
       $entity_types = $this->entityTypeManager->getDefinitions();
       foreach ($entity_types as $entity_type_id => $entity_type) {
-        $this->all[] = new CrossBundlesResourceType(
-          $entity_type_id,
-          $entity_type_id,
-          $entity_type->getClass(),
-          static::shouldBeInternalResourceType($entity_type)
-        );
+        if ($entity_type->getBundleEntityType()) {
+          $this->all[] = new CrossBundlesResourceType(
+            $entity_type_id,
+            '__all',
+            $entity_type->getClass(),
+            static::shouldBeInternalResourceType($entity_type)
+          );
+        }
       }
     }
     return $this->all;

--- a/admin_ui_support/modules/jsonapi_support/tests/src/Functional/CrossBundleCollectionTest.php
+++ b/admin_ui_support/modules/jsonapi_support/tests/src/Functional/CrossBundleCollectionTest.php
@@ -130,6 +130,10 @@ class CrossBundleCollectionTest extends BrowserTestBase {
       $response = $this->httpClient->request($method, 'jsonapi/node/' . Node::load(1)->uuid(), $request_options);
       $this->assertEquals('404', $response->getStatusCode());
     }
+
+    // A new route should not be created for entity types that don't support bundles.
+    $response = $this->httpClient->request('POST', 'jsonapi/node_type', $request_options);
+    $this->assertEquals('404', $response->getStatusCode());
   }
 
   /**


### PR DESCRIPTION
\Drupal\jsonapi_support\ResourceType\ResourceTypeRepository was not checking if the entity type support bundles. 

Because this resource type did not need a bundle it was using entity_type_id for bundle name.

But because of the ids for resources are created it was replacing resources provided by jsonapi. 

For instance there was existing resource that `node_type--node_type` that had the path `jsonapi/node_type/node_type`.
This was being removed. and replace with a resource with a path `jsonapi/node_type`.

When creating a new `\Drupal\jsonapi_support\ResourceType\CrossBundlesResourceType` now it is using '__all' for bundle. Therefore if bundle name is used that is the same as the entity type it will also not replace resource.

** Testing
This broke the permissions page in the React app because there was resource at `jsonapi/user_role/user_role` but no tests failed. Which means we don't have integration tests for this.