### PR TITLE
Fix API endpoints for user roles

### DIFF
--- a/src/utils/api/api.js
+++ b/src/utils/api/api.js
@@ -19,15 +19,15 @@ async function api(
       url = '/admin-ui-support/dblog-types?_format=json';
       break;
     case 'roles':
-      url = '/jsonapi/user_role/user_role';
+      url = '/jsonapi/user_role';
       options.headers.Accept = 'application/vnd.api+json';
       break;
     case 'role':
-      url = `/jsonapi/user_role/user_role/${parameters.role.id}`;
+      url = `/jsonapi/user_role/${parameters.role.id}`;
       options.headers.Accept = 'application/vnd.api+json';
       break;
     case 'role:patch':
-      url = `/jsonapi/user_role/user_role/${parameters.role.id}`;
+      url = `/jsonapi/user_role/${parameters.role.id}`;
       options.headers.Accept = 'application/vnd.api+json';
       options.method = 'PATCH';
       options.body = JSON.stringify({ data: parameters.role });


### PR DESCRIPTION
The API endpoints for Role related pages seem to have gotten mangled at some point. Currently on the master branch my Role listing page does not work, and I'm unable to save the role specific permission page. This update resolves that for me.

<img width="1278" alt="screen shot 2018-04-29 at 11 12 36 am" src="https://user-images.githubusercontent.com/8590743/39408583-444c1c20-4b9e-11e8-8308-e54c31c70de4.png">

