### PR TITLE
Process dies after 60 seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ composer run-script install
 
 ## Running
 ```
-composer run-script start
+cd docroot
+php core/scripts/drupal server
 ```
 
 Try visiting one of the converted pages, e.g. the user permissions or roles page.


### PR DESCRIPTION
```
$ composer run-script start

A script named install would override a Composer command and has been skipped
> cd docroot && php core/scripts/drupal server
Drupal development server started: <http://127.0.0.1:8888>
This server is not meant for production use.
One time login url: <http://127.0.0.1:8888/user/reset/1/1525873677/5Bnmpogv95OSZHOj_KWPtRi5xJRQ09mjvygDmQm2Y5g/login>
Press Ctrl-C to quit the Drupal development server.


  [Symfony\Component\Process\Exception\ProcessTimedOutException]
  The process "cd docroot && php core/scripts/drupal server" exceeded the timeout of 3
  00 seconds.
```

Possible solutions:

* Disable the timeout. This sounds like a good solution, but I argue we should teach people about ```drupal server``` instead of hiding it behind another command
* Use the actual php command by default. For me this is some level of documentation to tell people: Hey, this thing exists