### PR TITLE
Remove secondary (red) color from edit button.

### DIFF
--- a/src/components/05_pages/Content/Content.js
+++ b/src/components/05_pages/Content/Content.js
@@ -234,7 +234,6 @@ class Content extends Component {
                   </TableCell>
                   <TableCell style={{ whiteSpace: 'nowrap' }}>
                     <IconButton
-                      color="secondary"
                       aria-label="edit"
                       className={styles.button}
                       component={Link}


### PR DESCRIPTION
Makes both action buttons dark grey. [Discussed](https://drupal.slack.com/messages/C2SJQ5FMG/convo/C2SJQ5FMG-1528804382.000427/) with @ckrina about this and she approved.