### PR TITLE
Simple bulk operation support

### DIFF
--- a/admin_ui_support/admin_ui_support.routing.yml
+++ b/admin_ui_support/admin_ui_support.routing.yml
@@ -34,14 +34,14 @@ admin_ui_support.dblog_types:
     _permission: 'access site reports'
     _format: 'json'
 
-#admin_ui_support.dblog.overview:
-#  path: '/vfancy/admin/reports/dblog'
-#  defaults:
-#    _controller: '\Drupal\admin_ui_support\Controller\EmptyController::noop'
-#  options:
-#    _admin_related_route: 'dblog.overview'
-#  requirements:
-#    _permission: 'access site reports'
+admin_ui_support.dblog.overview:
+  path: '/vfancy/admin/reports/dblog'
+  defaults:
+    _controller: '\Drupal\admin_ui_support\Controller\EmptyController::noop'
+  options:
+    _admin_related_route: 'dblog.overview'
+  requirements:
+    _permission: 'access site reports'
 
 admin_ui_support.admin_ui_support_settings:
   path: '/admin/config/system/admin-ui-support'

--- a/admin_ui_support/admin_ui_support.routing.yml
+++ b/admin_ui_support/admin_ui_support.routing.yml
@@ -34,14 +34,14 @@ admin_ui_support.dblog_types:
     _permission: 'access site reports'
     _format: 'json'
 
-admin_ui_support.dblog.overview:
-  path: '/vfancy/admin/reports/dblog'
-  defaults:
-    _controller: '\Drupal\admin_ui_support\Controller\EmptyController::noop'
-  options:
-    _admin_related_route: 'dblog.overview'
-  requirements:
-    _permission: 'access site reports'
+#admin_ui_support.dblog.overview:
+#  path: '/vfancy/admin/reports/dblog'
+#  defaults:
+#    _controller: '\Drupal\admin_ui_support\Controller\EmptyController::noop'
+#  options:
+#    _admin_related_route: 'dblog.overview'
+#  requirements:
+#    _permission: 'access site reports'
 
 admin_ui_support.admin_ui_support_settings:
   path: '/admin/config/system/admin-ui-support'

--- a/src/actions/application.js
+++ b/src/actions/application.js
@@ -103,8 +103,6 @@ function* loadActions() {
     });
   } catch (error) {
     yield put(setMessage(error.toString()));
-  } finally {
-    yield put(hideLoading());
   }
 }
 

--- a/src/actions/application.js
+++ b/src/actions/application.js
@@ -78,7 +78,38 @@ function* loadContentTypes() {
   }
 }
 
+/**
+ * Gets all available action types.
+ */
+export const ACTIONS_REQUESTED = 'ACTIONS_REQUESTED';
+export const requestActions = () => ({
+  type: ACTIONS_REQUESTED,
+  payload: {},
+});
+
+export const getActionsCache = state => state.application.actions;
+export const ACTIONS_LOADED = 'ACTIONS_LOADED';
+function* loadActions() {
+  try {
+    let actions = yield select(getActionsCache);
+    if (!Object.keys(actions).length) {
+      actions = yield call(api, 'actions');
+    }
+    yield put({
+      type: ACTIONS_LOADED,
+      payload: {
+        actions,
+      },
+    });
+  } catch (error) {
+    yield put(setMessage(error.toString()));
+  } finally {
+    yield put(hideLoading());
+  }
+}
+
 export default function* watchRequestedMenu() {
   yield takeLatest(MENU_REQUESTED, loadMenu);
   yield takeLatest(CONTENT_TYPES_REQUESTED, loadContentTypes);
+  yield takeLatest(ACTIONS_REQUESTED, loadActions);
 }

--- a/src/actions/content.js
+++ b/src/actions/content.js
@@ -119,13 +119,15 @@ export const KNOWN_ACTIONS = [
 ];
 
 // @todo Find a better name
+// @todo How do we update the store with the new values of the nodes
+//    or the deleted nodes.
 export function* doActionExecute({ payload: { action, nids } }) {
   try {
     const contentList = yield select(state => state.content.contentList);
     const actions = nids
       .map(nid => {
         const node = contentList.filter(
-          contentItem => contentItem.attributes.nid == nid,
+          contentItem => String(contentItem.attributes.nid) === nid,
         )[0];
 
         let saveAction;

--- a/src/actions/content.js
+++ b/src/actions/content.js
@@ -141,10 +141,10 @@ export const SUPPORTED_ACTIONS = [
   'entity:unpublish_action:node',
 ];
 
-// @todo Find a better name
 // @todo How do we update the store with the new values of the nodes
-//    or the deleted nodes.
-export function* doActionExecute({ payload: { action, nids } }) {
+//    or the deleted nodes, see https://github.com/jsdrupal/drupal-admin-ui/issues/131
+// @todo Once jsonapi supports bulk operations, leverage it.
+export function* executeAction({ payload: { action, nids } }) {
   try {
     const contentList = yield select(state => state.content.contentList);
     const actions = nids
@@ -245,7 +245,7 @@ export function* doActionExecute({ payload: { action, nids } }) {
   }
 }
 
-function* doContentSave({ payload: { content } }) {
+function* saveContent({ payload: { content } }) {
   try {
     yield put(resetLoading());
     yield put(showLoading());
@@ -257,7 +257,7 @@ function* doContentSave({ payload: { content } }) {
   }
 }
 
-function* doContentDelete({ payload: { content } }) {
+function* deleteContent({ payload: { content } }) {
   try {
     yield put(resetLoading());
     yield put(showLoading());
@@ -271,7 +271,7 @@ function* doContentDelete({ payload: { content } }) {
 
 export default function* rootSaga() {
   yield takeLatest(CONTENT_REQUESTED, loadContent);
-  yield takeLatest(ACTION_EXECUTE, doActionExecute);
-  yield takeLatest(CONTENT_SAVE, doContentSave);
-  yield takeLatest(CONTENT_DELETE, doContentDelete);
+  yield takeLatest(ACTION_EXECUTE, executeAction);
+  yield takeLatest(CONTENT_SAVE, saveContent);
+  yield takeLatest(CONTENT_DELETE, deleteContent);
 }

--- a/src/components/05_pages/Content/Content.js
+++ b/src/components/05_pages/Content/Content.js
@@ -164,7 +164,9 @@ class Content extends Component {
   };
 
   render = () => {
-    const { page: { offset, limit } } = this.state;
+    const {
+      page: { offset, limit },
+    } = this.state;
     const { links, contentList } = this.props;
 
     // Calculate the highest known count.

--- a/src/components/05_pages/Content/Content.js
+++ b/src/components/05_pages/Content/Content.js
@@ -34,7 +34,7 @@ import {
 } from '../../../actions/application';
 import {
   requestContent,
-  KNOWN_ACTIONS,
+  SUPPORTED_ACTIONS,
   actionExecute,
 } from '../../../actions/content';
 
@@ -48,6 +48,12 @@ const styles = {
     position: fixed;
     right: 0;
     bottom: 0;
+  `,
+  action: css`
+    margin: 0.5rem;
+    margin-left: 0rem;
+    min-width: 8rem;
+    max-width: 19rem;
   `,
   formControl: css`
     margin: 0.5rem;
@@ -197,7 +203,7 @@ class Content extends Component {
 
         <div className={styles.filters}>
           {this.props.actions && (
-            <FormControl className={styles.formControl}>
+            <FormControl className={styles.action}>
               <InputLabel htmlFor="actions">Actions</InputLabel>
               <Select
                 value={this.state.action || ''}
@@ -219,7 +225,13 @@ class Content extends Component {
             </FormControl>
           )}
           {this.state.action && (
-            <Button onClick={this.executeAction} color="primary" variant="contained">Save</Button>
+            <Button
+              onClick={this.executeAction}
+              color="primary"
+              variant="contained"
+            >
+              Apply
+            </Button>
           )}
         </div>
 
@@ -329,7 +341,7 @@ const mapStateToProps = state => ({
   contentList: state.content.contentList,
   includes: state.content.includes,
   actions: state.application.actions.filter(action =>
-    KNOWN_ACTIONS.includes(action.attributes.plugin),
+    SUPPORTED_ACTIONS.includes(action.attributes.plugin),
   ),
 });
 

--- a/src/components/05_pages/Content/Content.js
+++ b/src/components/05_pages/Content/Content.js
@@ -248,7 +248,7 @@ class Content extends Component {
                   {
                     <TableCell padding="checkbox">
                       <Checkbox
-                        value={nid}
+                        value={String(nid)}
                         onChange={(event, checked) => {
                           this.setState(prevState => {
                             prevState.checked[nid] = checked;

--- a/src/components/05_pages/Permissions/Permissions.js
+++ b/src/components/05_pages/Permissions/Permissions.js
@@ -276,4 +276,7 @@ styles = {
   `,
 };
 
-export default connect(null, { setMessage, clearMessage })(Permissions);
+export default connect(
+  null,
+  { setMessage, clearMessage },
+)(Permissions);

--- a/src/components/05_pages/Reports/Dblog.js
+++ b/src/components/05_pages/Reports/Dblog.js
@@ -157,4 +157,7 @@ const mapStateToProps = ({ application: { dblog } }) => ({
   ...dblog,
 });
 
-export default connect(mapStateToProps, { requestDblogCollection })(Dblog);
+export default connect(
+  mapStateToProps,
+  { requestDblogCollection },
+)(Dblog);

--- a/src/components/05_pages/Roles/Roles.js
+++ b/src/components/05_pages/Roles/Roles.js
@@ -53,4 +53,7 @@ const mapStateToProps = ({ application: { roles } }) => ({
   roles,
 });
 
-export default connect(mapStateToProps, { requestRoles, cancelTask })(Roles);
+export default connect(
+  mapStateToProps,
+  { requestRoles, cancelTask },
+)(Roles);

--- a/src/components/06_wrappers/Default/Default.js
+++ b/src/components/06_wrappers/Default/Default.js
@@ -171,8 +171,11 @@ const mapStateToProps = state => ({
   drawerOpen: state.application.drawerOpen,
 });
 
-export default connect(mapStateToProps, {
-  requestMenu,
-  openDrawer,
-  closeDrawer,
-})(Default);
+export default connect(
+  mapStateToProps,
+  {
+    requestMenu,
+    openDrawer,
+    closeDrawer,
+  },
+)(Default);

--- a/src/components/06_wrappers/Default/Default.js
+++ b/src/components/06_wrappers/Default/Default.js
@@ -113,6 +113,9 @@ const mapStateToProps = state => ({
   menuLinks: state.application.menuLinks,
 });
 
-export default connect(mapStateToProps, {
-  requestMenu,
-})(Default);
+export default connect(
+  mapStateToProps,
+  {
+    requestMenu,
+  },
+)(Default);

--- a/src/reducers/application.js
+++ b/src/reducers/application.js
@@ -9,6 +9,7 @@ import {
   CLEAR_MESSAGE,
   MENU_LOADED,
   CONTENT_TYPES_LOADED,
+  ACTIONS_LOADED,
 } from '../actions/application';
 
 export const initialState = {
@@ -16,7 +17,9 @@ export const initialState = {
   menuLinks: [],
   filterString: '',
   contentTypes: {},
+  actions: [],
 };
+
 export default (state = initialState, action) => {
   switch (action.type) {
     case SET_MESSAGE: {
@@ -102,6 +105,12 @@ export default (state = initialState, action) => {
           }),
           {},
         ),
+      };
+    }
+    case ACTIONS_LOADED: {
+      return {
+        ...state,
+        actions: action.payload.actions.data,
       };
     }
     default: {

--- a/src/reducers/content.js
+++ b/src/reducers/content.js
@@ -1,8 +1,4 @@
-import {
-  CONTENT_LOADED,
-  CONTENT_DELETE,
-  CONTENT_SAVE,
-} from '../actions/content';
+import { CONTENT_LOADED, CONTENT_DELETE } from '../actions/content';
 
 export const initialState = {
   contentList: [],

--- a/src/reducers/content.js
+++ b/src/reducers/content.js
@@ -1,4 +1,8 @@
-import { CONTENT_LOADED } from '../actions/content';
+import {
+  CONTENT_LOADED,
+  CONTENT_DELETE,
+  CONTENT_SAVE,
+} from '../actions/content';
 
 export const initialState = {
   contentList: [],
@@ -28,6 +32,16 @@ export default (state = initialState, action) => {
           : [],
       };
     }
+
+    case CONTENT_DELETE: {
+      return {
+        ...state,
+        contentList: state.contentList.filter(
+          content => content.id !== action.payload.content.id,
+        ),
+      };
+    }
+
     default: {
       return { ...state };
     }

--- a/src/reducers/content.js
+++ b/src/reducers/content.js
@@ -21,6 +21,8 @@ export default (state = initialState, action) => {
         contentList: action.payload.contentList.data
           ? action.payload.contentList.data.map(content => ({
               ...content,
+              // @fixme Instead of doing that we should get the node type
+              // using the type relationship.
               type: content.type.substr(6),
             }))
           : [],

--- a/src/utils/api/api.js
+++ b/src/utils/api/api.js
@@ -40,9 +40,31 @@ async function api(
       url = '/jsonapi/node';
       options.headers.Accept = 'application/vnd.api+json';
       break;
+    case 'actions':
+      url = '/jsonapi/action';
+      options.headers.Accept = 'application/vnd.api+json';
+      break;
     case 'contentTypes':
       url = '/jsonapi/node_type';
       options.headers.Accept = 'application/vnd.api+json';
+      break;
+    case 'node:delete':
+      options.headers.Accept = 'application/vnd.api+json';
+      options.headers['Content-Type'] = 'application/vnd.api+json';
+      options.method = 'DELETE';
+      url = parameters.node.links.self.replace(
+        process.env.REACT_APP_DRUPAL_BASE_URL,
+        '',
+      );
+      break;
+    case 'node:save':
+      options.headers.Accept = 'application/vnd.api+json';
+      options.method = 'PATCH';
+      options.body = JSON.stringify({ data: parameters.node });
+      url = parameters.node.links.self.replace(
+        process.env.REACT_APP_DRUPAL_BASE_URL,
+        '',
+      );
       break;
     default:
       break;

--- a/src/utils/api/api.js
+++ b/src/utils/api/api.js
@@ -53,6 +53,13 @@ async function api(
       options.headers.Accept = 'application/vnd.api+json';
       break;
     case 'node:delete':
+      // Set the type to the right value for jsonapi to process.
+      // @todo Ideally this should not be differnet in the first place.
+      parameters.node = {
+        ...parameters.node,
+        type: parameters.node.type.includes('--') ? parameters.node.type : `node--${parameters.node.type}`,
+      };
+
       const deleteToken = await api('csrf_token');
       options.headers.Accept = 'application/vnd.api+json';
       options.headers['X-CSRF-Token'] = deleteToken;
@@ -64,6 +71,13 @@ async function api(
       );
       break;
     case 'node:save':
+      // Set the type to the right value for jsonapi to process.
+      // @todo Ideally this should not be differnet in the first place.
+      parameters.node = {
+        ...parameters.node,
+        type: parameters.node.type.includes('--') ? parameters.node.type : `node--${parameters.node.type}`,
+      };
+
       const saveToken = await api('csrf_token');
       options.headers.Accept = 'application/vnd.api+json';
       options.headers['X-CSRF-Token'] = saveToken;

--- a/src/utils/api/api.js
+++ b/src/utils/api/api.js
@@ -15,6 +15,10 @@ async function api(
     case 'dblog':
       url = '/jsonapi/watchdog_entity/watchdog_entity';
       break;
+    case 'csrf_token':
+      url = '/session/token';
+      options.text = true;
+      break;
     case 'dblog:types':
       url = '/admin-ui-support/dblog-types?_format=json';
       break;
@@ -49,7 +53,9 @@ async function api(
       options.headers.Accept = 'application/vnd.api+json';
       break;
     case 'node:delete':
+      const deleteToken = await api('csrf_token');
       options.headers.Accept = 'application/vnd.api+json';
+      options.headers['X-CSRF-Token'] = deleteToken;
       options.headers['Content-Type'] = 'application/vnd.api+json';
       options.method = 'DELETE';
       url = parameters.node.links.self.replace(
@@ -58,7 +64,9 @@ async function api(
       );
       break;
     case 'node:save':
+      const saveToken = await api('csrf_token');
       options.headers.Accept = 'application/vnd.api+json';
+      options.headers['X-CSRF-Token'] = saveToken;
       options.method = 'PATCH';
       options.body = JSON.stringify({ data: parameters.node });
       url = parameters.node.links.self.replace(
@@ -77,7 +85,12 @@ async function api(
         : ''
     }`,
     options,
-  ).then(res => res.json());
+  ).then(res => {
+    if (options.text) {
+      return res.text();
+    }
+    return res.json();
+  });
   return data;
 }
 

--- a/src/utils/api/api.js
+++ b/src/utils/api/api.js
@@ -57,10 +57,14 @@ async function api(
       // @todo Ideally this should not be differnet in the first place.
       parameters.node = {
         ...parameters.node,
-        type: parameters.node.type.includes('--') ? parameters.node.type : `node--${parameters.node.type}`,
+        type: parameters.node.type.includes('--')
+          ? parameters.node.type
+          : `node--${parameters.node.type}`,
       };
 
       const deleteToken = await api('csrf_token');
+      // @todo Delete requests sadly return non json.
+      options.text = true;
       options.headers.Accept = 'application/vnd.api+json';
       options.headers['X-CSRF-Token'] = deleteToken;
       options.headers['Content-Type'] = 'application/vnd.api+json';
@@ -75,7 +79,9 @@ async function api(
       // @todo Ideally this should not be differnet in the first place.
       parameters.node = {
         ...parameters.node,
-        type: parameters.node.type.includes('--') ? parameters.node.type : `node--${parameters.node.type}`,
+        type: parameters.node.type.includes('--')
+          ? parameters.node.type
+          : `node--${parameters.node.type}`,
       };
 
       const saveToken = await api('csrf_token');
@@ -100,6 +106,7 @@ async function api(
     }`,
     options,
   ).then(res => {
+    // CSRF tokens return text, not json.
     if (options.text) {
       return res.text();
     }


### PR DESCRIPTION
This PR adds some bulk operation support, see issue https://github.com/jsdrupal/drupal-admin-ui/issues/127

Right now the UI is really rough, I bet there is a lot which can be done:

* The user selects an action to be executed
* The user selects a bunch of nodes
* "Saving" applies the action on all these nodes
* Right now the endpoints are triggered, but the store itself is untouched.

Related discussion: https://github.com/jsdrupal/drupal-admin-ui/issues/131

TODO:

* [ ] Improve the user experience
* [ ] Figure out how to sync the store with the updates done on the content itself