### PR TITLE
Followup to #145 document properties of the new button.

### DIFF
--- a/src/components/02_atoms/OpsModalButton/OpsModalButton.js
+++ b/src/components/02_atoms/OpsModalButton/OpsModalButton.js
@@ -23,6 +23,9 @@ function Transition(props) {
  * Custom Properties :-
  *   title, string to appear in the modal dialog.
  *   text, string to appear below the title.
+ *   cancelText, string to appear in the cancel button.
+ *   confirmText, string to appear in the confirm button.
+ *   enterAction, function to be called when the confirm button is pressed.
  */
 class OpsModalButton extends React.Component {
   state = {

--- a/src/components/02_atoms/OpsModalButton/OpsModalButton.js
+++ b/src/components/02_atoms/OpsModalButton/OpsModalButton.js
@@ -21,7 +21,7 @@ function Transition(props) {
  * When pressed a modal dialog slides up into view.
  */
 class OpsModalButton extends React.Component {
-    static propTypes = {
+  static propTypes = {
     /**
      * The dialog title.
      */

--- a/src/components/02_atoms/OpsModalButton/OpsModalButton.js
+++ b/src/components/02_atoms/OpsModalButton/OpsModalButton.js
@@ -19,15 +19,34 @@ function Transition(props) {
  * see for example  '@material-ui/icons/Add'
  *
  * When pressed a modal dialog slides up into view.
- *
- * Custom Properties :-
- *   title, string to appear in the modal dialog.
- *   text, string to appear below the title.
- *   cancelText, string to appear in the cancel button.
- *   confirmText, string to appear in the confirm button.
- *   enterAction, function to be called when the confirm button is pressed.
  */
 class OpsModalButton extends React.Component {
+    static propTypes = {
+    /**
+     * The dialog title.
+     */
+    title: PropTypes.string.isRequired,
+    /**
+     * The text below the dialog title.
+     */
+    text: PropTypes.string.isRequired,
+    /**
+     * The confirm button label.
+     */
+    confirmText: PropTypes.string.isRequired,
+    /**
+     * The cancel button label.
+     */
+    cancelText: PropTypes.string.isRequired,
+    /**
+     * Children of the button.
+     */
+    children: PropTypes.node.isRequired,
+    /**
+     * Called when the confirm button is pressed.
+     */
+    enterAction: PropTypes.func.isRequired,
+  };
   state = {
     open: false,
   };
@@ -90,12 +109,4 @@ class OpsModalButton extends React.Component {
   }
 }
 
-OpsModalButton.propTypes = {
-  title: PropTypes.string.isRequired,
-  text: PropTypes.string.isRequired,
-  confirmText: PropTypes.string.isRequired,
-  cancelText: PropTypes.string.isRequired,
-  children: PropTypes.node.isRequired,
-  enterAction: PropTypes.func.isRequired,
-};
 export default OpsModalButton;


### PR DESCRIPTION
At the last moment when  #145 was being stitched together with the bulk operations issue the button labels where added as additional properties to the opModalButton.. this is a good thing to do 

But the annotation at the start of the class definition was not updated.

This is just a minor tidyup