### PR TITLE
keepMounted is causing errors and should be deleted

### DIFF
--- a/src/components/02_atoms/OpsModalButton/OpsModalButton.js
+++ b/src/components/02_atoms/OpsModalButton/OpsModalButton.js
@@ -78,7 +78,6 @@ class OpsModalButton extends React.Component {
         <Dialog
           open={this.state.open}
           TransitionComponent={Transition}
-          keepMounted="keepMounted"
           onClose={this.handleClose}
         >
           <DialogTitle>{title}</DialogTitle>


### PR DESCRIPTION
I want to fix up a mistake I made.

When OpsModalButton was created I copied example code from the material-ui website.
It must have been from a outdated version of material-ui

When I look with chrome dev tools the presence of the bad attribute is throwning errors in the console logs

It should be a boolean not a string, and the default is the sensible option so the prop can be deleted.

