### PR TITLE
For screenreaders and a11y fix the menu bar.

### DIFF
--- a/src/components/06_wrappers/Default/Default.js
+++ b/src/components/06_wrappers/Default/Default.js
@@ -81,31 +81,27 @@ class Default extends React.Component {
               <MenuIcon />
             </IconButton>
           )}
-          <Divider />
-          <List data-nightwatch="menu">
-            {this.props.menuLinks.map(({ link: menuLink }) => (
-              <ListItem
-                key={menuLink.url.replace(/\//g, '-')}
-                component="li"
-                button
-              >
-                <Link
-                  to={menuLink.url}
-                  className={styles.menuLink}
-                  role="button"
-                >
-                  {iconMap[menuLink.url] ? (
-                    <ListItemIcon>{iconMap[menuLink.url]}</ListItemIcon>
-                  ) : (
-                    ''
-                  )}
-                  <ListItemText primary={menuLink.title} />
-                </Link>
-              </ListItem>
-            ))}
-          </List>
-          {this.props.menuLinks.length ? <Divider /> : ''}
         </div>
+        <Divider />
+        <List data-nightwatch="menu">
+          {this.props.menuLinks.map(({ link: menuLink }) => (
+            <ListItem
+              key={menuLink.url.replace(/\//g, '-')}
+              component="li"
+              button
+            >
+              <Link to={menuLink.url} className={styles.menuLink} role="button">
+                {iconMap[menuLink.url] ? (
+                  <ListItemIcon>{iconMap[menuLink.url]}</ListItemIcon>
+                ) : (
+                  ''
+                )}
+                <ListItemText primary={menuLink.title} />
+              </Link>
+            </ListItem>
+          ))}
+        </List>
+        {this.props.menuLinks.length ? <Divider /> : ''}
       </Drawer>
 
       <main className={styles.main} id={styles.main}>
@@ -128,7 +124,7 @@ styles = {
   menuButton: css`
     margin: 8px 12px;
   `,
-  menuWrapper: css`
+  menuButtonWrapper: css`
     display: flex;
     justify-content: flex-end;
   `,

--- a/src/components/06_wrappers/Default/Default.js
+++ b/src/components/06_wrappers/Default/Default.js
@@ -11,7 +11,6 @@ import IconButton from '@material-ui/core/IconButton';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
-import Divider from '@material-ui/core/Divider';
 import ViewListIcon from '@material-ui/icons/ViewList';
 import BuildIcon from '@material-ui/icons/Build';
 import ColorLensIcon from '@material-ui/icons/ColorLens';
@@ -54,54 +53,52 @@ class Default extends React.Component {
   render = () => (
     <div className={styles.outerWrapper}>
       <CssBaseline />
-      <Drawer
-        variant="permanent"
-        classes={{
-          paper: `${styles.drawerPaper} ${!this.props.drawerOpen &&
-            styles.drawerPaperClose}`,
-        }}
-        open={this.props.drawerOpen}
-      >
-        <div className={styles.menuButtonWrapper}>
-          {this.props.drawerOpen ? (
-            <IconButton
-              onClick={this.props.closeDrawer}
-              className={styles.menuButton}
-            >
-              <ChevronLeftIcon />
-            </IconButton>
-          ) : (
-            <IconButton
-              color="inherit"
-              aria-label="open drawer"
-              onClick={this.props.openDrawer}
-              className={styles.menuButton}
-            >
-              <MenuIcon />
-            </IconButton>
-          )}
-        </div>
-        <Divider />
-        <List data-nightwatch="menu">
-          {this.props.menuLinks.map(({ link: menuLink }) => (
-            <ListItem
-              button
-              component={Link}
-              to={menuLink.url}
-              key={menuLink.url.replace(/\//g, '-')}
-            >
-              {iconMap[menuLink.url] ? (
-                <ListItemIcon>{iconMap[menuLink.url]}</ListItemIcon>
-              ) : (
-                ''
-              )}
-              <ListItemText primary={menuLink.title} />
-            </ListItem>
-          ))}
-        </List>
-        {this.props.menuLinks.length ? <Divider /> : ''}
-      </Drawer>
-
+      <div className={styles.menuColumn}>
+        {this.props.drawerOpen ? (
+          <IconButton
+            aria-label="close drawer"
+            onClick={this.props.closeDrawer}
+            className={styles.menuButton}
+          >
+            <ChevronLeftIcon />
+          </IconButton>
+        ) : (
+          <IconButton
+            color="inherit"
+            aria-label="open drawer"
+            onClick={this.props.openDrawer}
+            className={styles.menuButton}
+          >
+            <MenuIcon />
+          </IconButton>
+        )}
+        <Drawer
+          variant="permanent"
+          classes={{
+            paper: `${styles.drawerPaper} ${!this.props.drawerOpen &&
+              styles.drawerPaperClose}`,
+          }}
+          open={this.props.drawerOpen}
+        >
+          <List data-nightwatch="menu">
+            {this.props.menuLinks.map(({ link: menuLink }) => (
+              <ListItem key={menuLink.url.replace(/\//g, '-')}>
+                <Link
+                  component={Link}
+                  to={menuLink.url}
+                  aria-label={menuLink.title}
+                />
+                {iconMap[menuLink.url] ? (
+                  <ListItemIcon>{iconMap[menuLink.url]}</ListItemIcon>
+                ) : (
+                  ''
+                )}
+                <ListItemText primary={menuLink.title} />
+              </ListItem>
+            ))}
+          </List>
+        </Drawer>
+      </div>
       <main className={styles.main} id={styles.main}>
         <ErrorBoundary>
           {this.props.messages.map(message => (
@@ -118,9 +115,10 @@ styles = {
   menuButton: css`
     margin: 8px 12px;
   `,
-  menuButtonWrapper: css`
+  menuColumn: css`
     display: flex;
-    justify-content: flex-end;
+    flex-direction: column;
+    justify-content: flex-start;
   `,
   outerWrapper: css`
     height: 100%;

--- a/src/components/06_wrappers/Default/Default.js
+++ b/src/components/06_wrappers/Default/Default.js
@@ -11,6 +11,7 @@ import IconButton from '@material-ui/core/IconButton';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
+import Divider from '@material-ui/core/Divider';
 import ViewListIcon from '@material-ui/icons/ViewList';
 import BuildIcon from '@material-ui/icons/Build';
 import ColorLensIcon from '@material-ui/icons/ColorLens';
@@ -53,33 +54,34 @@ class Default extends React.Component {
   render = () => (
     <div className={styles.outerWrapper}>
       <CssBaseline />
-      <div className={styles.menuColumn}>
-        {this.props.drawerOpen ? (
-          <IconButton
-            aria-label="close drawer"
-            onClick={this.props.closeDrawer}
-            className={styles.menuButton}
-          >
-            <ChevronLeftIcon />
-          </IconButton>
-        ) : (
-          <IconButton
-            color="inherit"
-            aria-label="open drawer"
-            onClick={this.props.openDrawer}
-            className={styles.menuButton}
-          >
-            <MenuIcon />
-          </IconButton>
-        )}
-        <Drawer
-          variant="permanent"
-          classes={{
-            paper: `${styles.drawerPaper} ${!this.props.drawerOpen &&
-              styles.drawerPaperClose}`,
-          }}
-          open={this.props.drawerOpen}
-        >
+      <Drawer
+        variant="permanent"
+        classes={{
+          paper: `${styles.drawerPaper} ${!this.props.drawerOpen &&
+            styles.drawerPaperClose}`,
+        }}
+        open={this.props.drawerOpen}
+      >
+        <div className={styles.menuButtonWrapper}>
+          {this.props.drawerOpen ? (
+            <IconButton
+              aria-label="close drawer"
+              onClick={this.props.closeDrawer}
+              className={styles.menuButton}
+            >
+              <ChevronLeftIcon />
+            </IconButton>
+          ) : (
+            <IconButton
+              color="inherit"
+              aria-label="open drawer"
+              onClick={this.props.openDrawer}
+              className={styles.menuButton}
+            >
+              <MenuIcon />
+            </IconButton>
+          )}
+          <Divider />
           <List data-nightwatch="menu">
             {this.props.menuLinks.map(({ link: menuLink }) => (
               <ListItem
@@ -102,8 +104,10 @@ class Default extends React.Component {
               </ListItem>
             ))}
           </List>
-        </Drawer>
-      </div>
+          {this.props.menuLinks.length ? <Divider /> : ''}
+        </div>
+      </Drawer>
+
       <main className={styles.main} id={styles.main}>
         <ErrorBoundary>
           {this.props.messages.map(message => (
@@ -124,10 +128,9 @@ styles = {
   menuButton: css`
     margin: 8px 12px;
   `,
-  menuColumn: css`
+  menuWrapper: css`
     display: flex;
-    flex-direction: column;
-    justify-content: flex-start;
+    justify-content: flex-end;
   `,
   outerWrapper: css`
     height: 100%;

--- a/src/components/06_wrappers/Default/Default.js
+++ b/src/components/06_wrappers/Default/Default.js
@@ -87,7 +87,11 @@ class Default extends React.Component {
                 component="li"
                 button
               >
-                <Link to={menuLink.url} className={styles.menuLink}>
+                <Link
+                  to={menuLink.url}
+                  className={styles.menuLink}
+                  role="button"
+                >
                   {iconMap[menuLink.url] ? (
                     <ListItemIcon>{iconMap[menuLink.url]}</ListItemIcon>
                   ) : (

--- a/src/components/06_wrappers/Default/Default.js
+++ b/src/components/06_wrappers/Default/Default.js
@@ -82,18 +82,19 @@ class Default extends React.Component {
         >
           <List data-nightwatch="menu">
             {this.props.menuLinks.map(({ link: menuLink }) => (
-              <ListItem key={menuLink.url.replace(/\//g, '-')}>
-                <Link
-                  component={Link}
-                  to={menuLink.url}
-                  aria-label={menuLink.title}
-                />
-                {iconMap[menuLink.url] ? (
-                  <ListItemIcon>{iconMap[menuLink.url]}</ListItemIcon>
-                ) : (
-                  ''
-                )}
-                <ListItemText primary={menuLink.title} />
+              <ListItem
+                key={menuLink.url.replace(/\//g, '-')}
+                component="li"
+                button
+              >
+                <Link to={menuLink.url} className={styles.menuLink}>
+                  {iconMap[menuLink.url] ? (
+                    <ListItemIcon>{iconMap[menuLink.url]}</ListItemIcon>
+                  ) : (
+                    ''
+                  )}
+                  <ListItemText primary={menuLink.title} />
+                </Link>
               </ListItem>
             ))}
           </List>
@@ -112,6 +113,10 @@ class Default extends React.Component {
 }
 
 styles = {
+  menuLink: css`
+    display: inherit;
+    text-decoration: inherit;
+  `,
   menuButton: css`
     margin: 8px 12px;
   `,

--- a/src/tests/Nightwatch/Tests/menu.js
+++ b/src/tests/Nightwatch/Tests/menu.js
@@ -6,7 +6,7 @@ module.exports = {
       .relativeURL('/')
       .waitForElementVisible('button[aria-label="open drawer"]')
       .click('button[aria-label="open drawer"]')
-      .waitForElementVisible('[data-nightwatch="menu"] a[role="button"]')
+      .waitForElementVisible('[data-nightwatch="menu"] li a[role="button"]')
       .getText('[data-nightwatch="menu"] a[role="button"]', function menuText(
         result,
       ) {


### PR DESCRIPTION
## Issue

https://github.com/jsdrupal/drupal-admin-ui/issues/196

## Screenshot / UI changes

screen readers are given a more semantically correct DOM structure from which to work from.

## Testing instructions

Run chrome's lighthouse accessibility tests to expose all current  failures.

Once  the PR is used the bad structure errors and warning related to the menubar disappear

Please note if you look at localhost:3000 you will see lots of errors related the main page 
there are being removed in a separate issue.( see #178 ) 



