### PR TITLE
Remove horizontal scrollbar widget from the menu bar.(#202)

### DIFF
--- a/src/components/06_wrappers/Default/Default.js
+++ b/src/components/06_wrappers/Default/Default.js
@@ -137,7 +137,7 @@ styles = {
     transition: width 225ms cubic-bezier(0.4, 0, 0.6, 1) 0ms;
   `,
   drawerPaperClose: css`
-    overflow-x: 'hidden';
+    overflow-x: hidden;
     transition: none;
     width: 72px;
     transition: width 195ms cubic-bezier(0.4, 0, 0.6, 1) 0ms;

--- a/src/tests/Nightwatch/Tests/menu.js
+++ b/src/tests/Nightwatch/Tests/menu.js
@@ -4,6 +4,8 @@ module.exports = {
     browser
       .logUserIn()
       .relativeURL('/')
+      .waitForElementVisible('button[aria-label="open drawer"]', 10000)
+      .click('button[aria-label="open drawer"]')
       .waitForElementVisible('[data-nightwatch="menu"] a[role="button"]', 10000)
       .getText('[data-nightwatch="menu"] a[role="button"]', function menuText(
         result,


### PR DESCRIPTION
## Issue

https://github.com/jsdrupal/drupal-admin-ui/issues/202

see main issue for the screen shot

Look at the main content page - see the scrollbars can be seen as visual blemish.
[to the left and just above the watercress table row. ]

Chrome's devtools were reporting the  'hidden' property was invalid --  hidden without the quotes is a valid property!



