### PR TITLE
Call end() on nightwatch tests (trying rebuild)

### DIFF
--- a/src/tests/Nightwatch/Tests/menu.js
+++ b/src/tests/Nightwatch/Tests/menu.js
@@ -11,6 +11,7 @@ module.exports = {
         result,
       ) {
         this.assert.strictEqual(result.value, 'Content');
-      });
+      })
+      .end();
   },
 };

--- a/src/tests/Nightwatch/Tests/menu.js
+++ b/src/tests/Nightwatch/Tests/menu.js
@@ -1,6 +1,7 @@
 module.exports = {
   '@tags': ['menu'],
   menuRenders(browser) {
+    // force rebuild.
     browser
       .logUserIn()
       .relativeURL('/')


### PR DESCRIPTION
NOTE: this is a dup of https://github.com/jsdrupal/drupal-admin-ui/pull/210 to see if rebuilding makes nightwatch tests pass.

## Issue

https://github.com/jsdrupal/drupal-admin-ui/issues/209

## Screenshot / UI changes

NA

## Testing instructions

`yarn test:functional`





