### PR TITLE
change the default waiting time for elements

### DIFF
--- a/src/tests/Nightwatch/Tests/menu.js
+++ b/src/tests/Nightwatch/Tests/menu.js
@@ -4,9 +4,9 @@ module.exports = {
     browser
       .logUserIn()
       .relativeURL('/')
-      .waitForElementVisible('button[aria-label="open drawer"]', 10000)
+      .waitForElementVisible('button[aria-label="open drawer"]')
       .click('button[aria-label="open drawer"]')
-      .waitForElementVisible('[data-nightwatch="menu"] a[role="button"]', 10000)
+      .waitForElementVisible('[data-nightwatch="menu"] a[role="button"]')
       .getText('[data-nightwatch="menu"] a[role="button"]', function menuText(
         result,
       ) {

--- a/src/tests/Nightwatch/globals.js
+++ b/src/tests/Nightwatch/globals.js
@@ -6,6 +6,7 @@ import fs from 'fs';
 
 module.exports = {
   asyncHookTimeout: 60000,
+  waitForConditionTimeout: 10000,
   before(done) {
     chromedriver.start();
     done();


### PR DESCRIPTION
We fixed the nightwatch random failures by passing along time manually how log we want to wait for elements to appear.
For new tests we then started to pass along the same number so it seems more sensible to change the default.