### PR TITLE
Add PageTitle component

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-redux-loading-bar": "^3.1.2",
     "react-router-dom": "^4.2.2",
     "react-router-redux": "^5.0.0-alpha.9",
+    "react-side-effect": "^1.1.5",
     "react-sticky": "^6.0.2",
     "redux": "^3.7.2",
     "redux-devtools-extension": "^2.13.2",

--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,6 @@
     -->
     <link href="https://fonts.googleapis.com/css?family=Open+Sans|Roboto" rel="stylesheet">
     <noscript id="jss-insertion-point"></noscript>
-    <title>React App</title>
   </head>
   <body>
     <noscript>

--- a/src/components/02_atoms/PageTitle/PageTitle.js
+++ b/src/components/02_atoms/PageTitle/PageTitle.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import withSideEffect from 'react-side-effect';
+import { css } from 'emotion';
+
+import Typography from '@material-ui/core/Typography';
+
+const styles = {
+  title: css`
+    margin-bottom: 15px;
+    margin-left: 3px;
+  `,
+};
+
+const PageTitle = ({ children }) => (
+  <Typography variant="headline" classes={{ root: styles.title }}>{children}</Typography>
+);
+
+PageTitle.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+function reducePropsToState(propsList) {
+  const innermostProps = propsList[propsList.length - 1];
+  if (innermostProps) {
+    return innermostProps.children;
+  }
+}
+
+function handleStateChangeOnClient(title) {
+  document.title = title || '';
+}
+
+export default withSideEffect(reducePropsToState, handleStateChangeOnClient)(
+  PageTitle,
+);

--- a/src/components/02_atoms/PageTitle/PageTitle.js
+++ b/src/components/02_atoms/PageTitle/PageTitle.js
@@ -13,7 +13,9 @@ const styles = {
 };
 
 const PageTitle = ({ children }) => (
-  <Typography variant="headline" classes={{ root: styles.title }}>{children}</Typography>
+  <Typography variant="headline" classes={{ root: styles.title }}>
+    {children}
+  </Typography>
 );
 
 PageTitle.propTypes = {
@@ -25,6 +27,8 @@ function reducePropsToState(propsList) {
   if (innermostProps) {
     return innermostProps.children;
   }
+
+  return false;
 }
 
 function handleStateChangeOnClient(title) {

--- a/src/components/02_atoms/PageTitle/PageTitle.js
+++ b/src/components/02_atoms/PageTitle/PageTitle.js
@@ -22,18 +22,18 @@ PageTitle.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-function reducePropsToState(propsList) {
+const reducePropsToState = propsList => {
   const innermostProps = propsList[propsList.length - 1];
   if (innermostProps) {
     return innermostProps.children;
   }
 
   return false;
-}
+};
 
-function handleStateChangeOnClient(title) {
+const handleStateChangeOnClient = title => {
   document.title = title || '';
-}
+};
 
 export default withSideEffect(reducePropsToState, handleStateChangeOnClient)(
   PageTitle,

--- a/src/components/02_atoms/PageTitle/index.js
+++ b/src/components/02_atoms/PageTitle/index.js
@@ -1,0 +1,3 @@
+import PageTitle from './PageTitle';
+
+export default PageTitle;

--- a/src/components/05_pages/AddContent/AddContent.js
+++ b/src/components/05_pages/AddContent/AddContent.js
@@ -10,6 +10,7 @@ import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import { requestContentTypes } from '../../../actions/application';
+import PageTitle from '../../02_atoms/PageTitle';
 
 const styles = {
   root: css`
@@ -32,6 +33,7 @@ class AddContent extends Component {
   }
   render = () => (
     <div className={styles.root}>
+      <PageTitle>Add content</PageTitle>
       <Paper>
         <List>
           {Object.keys(this.props.contentTypes).map(contentType => (

--- a/src/components/05_pages/Content/Content.js
+++ b/src/components/05_pages/Content/Content.js
@@ -31,6 +31,7 @@ import EditIcon from '@material-ui/icons/Edit';
 import DeleteIcon from '@material-ui/icons/Delete';
 
 import OpsModalButton from '../../02_atoms/OpsModalButton/OpsModalButton';
+import PageTitle from '../../02_atoms/PageTitle';
 
 import {
   requestContentTypes,
@@ -181,6 +182,7 @@ class Content extends Component {
 
     return (
       <div className={styles.root}>
+        <PageTitle>Content</PageTitle>
         <Paper>
           <div className={styles.filters}>
             <TextField

--- a/src/components/05_pages/NodeForm/index.js
+++ b/src/components/05_pages/NodeForm/index.js
@@ -1,9 +1,9 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { css } from 'emotion';
-import Widgets from './Widgets';
-
 import Paper from '@material-ui/core/Paper';
+
+import Widgets from './Widgets';
 import PageTitle from '../../02_atoms/PageTitle';
 
 const lazyFunction = f => (props, propName, componentName, ...rest) =>

--- a/src/components/05_pages/NodeForm/index.js
+++ b/src/components/05_pages/NodeForm/index.js
@@ -1,7 +1,10 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { css } from 'emotion';
 import Widgets from './Widgets';
+
+import Paper from '@material-ui/core/Paper';
+import PageTitle from '../../02_atoms/PageTitle';
 
 const lazyFunction = f => (props, propName, componentName, ...rest) =>
   f(props, propName, componentName, ...rest);
@@ -64,34 +67,39 @@ class NodeForm extends React.Component {
 
   render() {
     return (
-      <form className={styles.container}>
-        {Object.entries(this.props.uiMetadata)
-          .map(([fieldName, { widget, inputProps }]) => {
-            if (Widgets[widget]) {
-              // @todo We need to pass along props.
-              // @todo How do we handle cardinality together with jsonapi
-              // making a distinction between single value fields and multi value fields.
-              const fieldSchema = this.getSchemaInfo(
-                this.props.schema,
-                fieldName,
-              );
+      <Fragment>
+        <PageTitle>Create {this.props.bundle}</PageTitle>
+        <Paper>
+          <form className={styles.container}>
+            {Object.entries(this.props.uiMetadata)
+              .map(([fieldName, { widget, inputProps }]) => {
+                if (Widgets[widget]) {
+                  // @todo We need to pass along props.
+                  // @todo How do we handle cardinality together with jsonapi
+                  // making a distinction between single value fields and multi value fields.
+                  const fieldSchema = this.getSchemaInfo(
+                    this.props.schema,
+                    fieldName,
+                  );
 
-              return React.createElement(this.props.widgets[widget], {
-                key: fieldName,
-                entityTypeId: this.props.entityTypeId,
-                bundle: this.props.bundle,
-                fieldName,
-                value: this.state.entity[fieldName],
-                label: fieldSchema && fieldSchema.title,
-                schema: fieldSchema,
-                onChange: this.onFieldChange(fieldName),
-                inputProps,
-              });
-            }
-            return null;
-          })
-          .filter(x => x)}
-      </form>
+                  return React.createElement(this.props.widgets[widget], {
+                    key: fieldName,
+                    entityTypeId: this.props.entityTypeId,
+                    bundle: this.props.bundle,
+                    fieldName,
+                    value: this.state.entity[fieldName],
+                    label: fieldSchema && fieldSchema.title,
+                    schema: fieldSchema,
+                    onChange: this.onFieldChange(fieldName),
+                    inputProps,
+                  });
+                }
+                return null;
+              })
+              .filter(x => x)}
+          </form>
+        </Paper>
+      </Fragment>
     );
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8128,6 +8128,13 @@ react-scripts@1.1.1:
   optionalDependencies:
     fsevents "^1.1.3"
 
+react-side-effect@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-1.1.5.tgz#f26059e50ed9c626d91d661b9f3c8bb38cd0ff2d"
+  dependencies:
+    exenv "^1.2.1"
+    shallowequal "^1.0.1"
+
 react-split-pane@^0.1.77:
   version "0.1.81"
   resolved "https://registry.yarnpkg.com/react-split-pane/-/react-split-pane-0.1.81.tgz#b1e8b82e0a6edd10f18fd639a5f512db3cbbb4e6"
@@ -8808,6 +8815,10 @@ shallowequal@^0.2.2:
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-0.2.2.tgz#1e32fd5bcab6ad688a4812cb0cc04efc75c7014e"
   dependencies:
     lodash.keys "^3.1.2"
+
+shallowequal@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
 
 shebang-command@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
## Screenshot / UI changes

This create `PageTitle` component which has a side effect to change the document title. This takes into accounts requirements set on https://github.com/jsdrupal/drupal-admin-ui/issues/184.

A downside on the current approach compared to what I proposed as an alternative there is that we cannot pre-fetch the title from the component, meaning that initially the page will render using wrong page title.

## Testing instructions

Content related pages should have titles, and when navigating between pages the document title should change.



