### PR TITLE
Let reducers default case returns the untouched state

### DIFF
--- a/src/reducers/application.js
+++ b/src/reducers/application.js
@@ -135,8 +135,7 @@ export default (state = initialState, action) => {
         actions: action.payload.actions.data,
       };
     }
-    default: {
-      return { ...state };
-    }
+    default:
+      return state;
   }
 };

--- a/src/reducers/content.js
+++ b/src/reducers/content.js
@@ -51,8 +51,7 @@ export default (state = initialState, action) => {
       };
     }
 
-    default: {
-      return { ...state };
-    }
+    default:
+      return state;
   }
 };


### PR DESCRIPTION
The default case of the reducers returns a copy of the state, this could cause unnecessary UI updates. The PR fix the code returning the untouched state.




