### PR TITLE
Improve steps used to setup Drupal for integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,6 @@ jobs:
                 cd ../
                 composer create-project jsdrupal/drupal-admin-ui-demo -s dev --prefer-dist
                 cd drupal-admin-ui-demo
-                composer devify
                 mv ~/project drupal-admin-ui
                 composer config repositories.repo-name path "./drupal-admin-ui/admin_ui_support"
                 composer require justafish/drupal-admin-ui-support

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,12 +62,11 @@ jobs:
                 cd ../
                 composer create-project jsdrupal/drupal-admin-ui-demo -s dev --prefer-dist
                 cd drupal-admin-ui-demo
-                composer setup
                 composer devify
-                composer config repositories.repo-name path "../project/admin_ui_support"
-                composer require justafish/drupal-admin-ui-support
-                rm -rf drupal-admin-ui
                 mv ~/project drupal-admin-ui
+                composer config repositories.repo-name path "./drupal-admin-ui/admin_ui_support"
+                composer require justafish/drupal-admin-ui-support
+                composer setup
         - save_cache:
             key: *integration-build-key
             paths:


### PR DESCRIPTION
This PR changes the Drupal installation commands for the integration test. This tries to tackle various problems at once:
1. The commands run cloned git repositories not used for testing which made following the installation steps slightly more complex than it could be.
2. Drupal was installed using the latest dev code, not the actual code being tested. This could have caused failures if we changed the installation requirements (not sure if this is the case since the tests install Drupal separately always).
3. As a side benefit this should also make the tests run a bit faster

We do need a follow-up to add usages of the commands to the demo repository to make sure all commands are being at least somewhat tested.

