### PR TITLE
#186 Add storybook for OpsModalButton wrapped in a table.

### DIFF
--- a/src/components/02_atoms/OpsModalButton/OpsModalButton.stories.js
+++ b/src/components/02_atoms/OpsModalButton/OpsModalButton.stories.js
@@ -11,7 +11,19 @@ import TableRow from '@material-ui/core/TableRow';
 
 import OpsModalButton from './OpsModalButton';
 
-storiesOf('Table Operations/OpsModalButton', module)
+storiesOf('OpsModalButton', module)
+  .add('Default', () => (
+    <OpsModalButton
+      aria-label="edit"
+      title="Are you sure that you want to edit this element?"
+      text="This action cannot be undone."
+      cancelText="Cancel"
+      confirmText="Edit"
+      enterAction={() => {}}
+    >
+      <EditIcon />
+    </OpsModalButton>
+  ))
   .addDecorator(story => (
     <Table>
       <TableHead>
@@ -28,7 +40,7 @@ storiesOf('Table Operations/OpsModalButton', module)
       </TableBody>
     </Table>
   ))
-  .addWithJSX('Default', () => (
+  .addWithJSX('Inside a table column', () => (
     <OpsModalButton
       aria-label="edit"
       title="Are you sure that you want to edit this element?"

--- a/src/components/02_atoms/OpsModalButton/OpsModalButton.stories.js
+++ b/src/components/02_atoms/OpsModalButton/OpsModalButton.stories.js
@@ -11,9 +11,8 @@ import TableRow from '@material-ui/core/TableRow';
 
 import OpsModalButton from './OpsModalButton';
 
-storiesOf('Table Operations/OpsModalButton', module).addWithJSX(
-  'Default',
-  () => (
+storiesOf('Table Operations/OpsModalButton', module)
+  .addDecorator(story => (
     <Table>
       <TableHead>
         <TableRow>
@@ -24,20 +23,20 @@ storiesOf('Table Operations/OpsModalButton', module).addWithJSX(
       <TableBody>
         <TableRow>
           <TableCell>Push button to see the modal pop up.</TableCell>
-          <TableCell>
-            <OpsModalButton
-              aria-label="edit"
-              title="Are you sure that you want to edit this element?"
-              text="This action cannot be undone."
-              cancelText="Cancel"
-              confirmText="Edit"
-              enterAction={() => {}}
-            >
-              <EditIcon />
-            </OpsModalButton>
-          </TableCell>
+          <TableCell>{story()}</TableCell>
         </TableRow>
       </TableBody>
     </Table>
-  ),
-);
+  ))
+  .addWithJSX('Default', () => (
+    <OpsModalButton
+      aria-label="edit"
+      title="Are you sure that you want to edit this element?"
+      text="This action cannot be undone."
+      cancelText="Cancel"
+      confirmText="Edit"
+      enterAction={() => {}}
+    >
+      <EditIcon />
+    </OpsModalButton>
+  ));

--- a/src/components/02_atoms/OpsModalButton/OpsModalButton.stories.js
+++ b/src/components/02_atoms/OpsModalButton/OpsModalButton.stories.js
@@ -1,0 +1,43 @@
+import React from 'react';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+
+import EditIcon from '@material-ui/icons/Edit';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
+
+import OpsModalButton from './OpsModalButton';
+
+storiesOf('Table Operations/OpsModalButton', module).addWithJSX(
+  'Default',
+  () => (
+    <Table>
+      <TableHead>
+        <TableRow>
+          <TableCell>Title</TableCell>
+          <TableCell>Operations</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        <TableRow>
+          <TableCell>Push button to see the modal pop up.</TableCell>
+          <TableCell>
+            <OpsModalButton
+              aria-label="edit"
+              title="Are you sure that you want to edit this element?"
+              text="This action cannot be undone."
+              cancelText="Cancel"
+              confirmText="Edit"
+              enterAction={() => {}}
+            >
+              <EditIcon />
+            </OpsModalButton>
+          </TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
+  ),
+);


### PR DESCRIPTION
## Issue

https://github.com/jsdrupal/drupal-admin-ui/issues/235

## Testing instructions

run:-

yarn storybook

See new page for the OpsModalButton

The button is on the right.


