### PR TITLE
Disable actions menu item when no nodes are selected.

### DIFF
--- a/src/components/05_pages/Content/Content.js
+++ b/src/components/05_pages/Content/Content.js
@@ -267,7 +267,13 @@ class Content extends Component {
           </div>
           <div className={styles.filters}>
             {this.props.actions && (
-              <FormControl className={styles.action}>
+              <FormControl
+                className={styles.action}
+                disabled={
+                  Object.values(this.state.checked).filter(Boolean).length ===
+                    0 || false
+                }
+              >
                 <InputLabel htmlFor="action">Actions</InputLabel>
                 <Select
                   value={this.state.action || ''}


### PR DESCRIPTION
## Issue

The group actions menu item should be disabled if no items are selected.

![disabled](https://user-images.githubusercontent.com/1090713/43230407-f8c98b20-901c-11e8-84af-83481185fb6e.gif)

## Testing instructions

- ensure you are unable to example the actions drop down when no menu items are selected




