### PR TITLE
Hide react-axe behind an environment variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ cd drupal-admin-ui
 yarn start
 ```
 
+### React AXE
+
+Due to outstanding performance issues, `react-axe` is behind a flag. To enable the assessment provided by `react-axe` pass an environment variable when starting the application.
+
+```
+REACT_APP_AXE=true yarn start
+```
 
 ## Commands
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,9 @@ import ReactDOM from 'react-dom';
 import App from './App';
 import registerServiceWorker from './registerServiceWorker';
 
-if (process.env.NODE_ENV !== 'production') {
+// Disable react-axe without an additional cli flag.
+// See README.md for more information.
+if (process.env.NODE_ENV !== 'production' && process.env.REACT_APP_AXE) {
   // eslint-disable-next-line import/no-extraneous-dependencies, global-require
   const axe = require('react-axe');
   axe(React, ReactDOM);


### PR DESCRIPTION
## Issue

`react-axe` causes some outstanding performance issues, and a nasty call-stack error when sorting the content listing table.

![react-axe](https://user-images.githubusercontent.com/1090713/43343851-a6a8b10a-919c-11e8-9b30-9768017551cd.gif)

## Screenshot / UI changes

Disable `react-axe` unless you specify a environment variable, `REACT_APP_AXE=true yarn start`

## Testing instructions

Start without `react-axe` and be amazed how fast everything is.




