### PR TITLE
change to openapi beta2

### DIFF
--- a/admin_ui_support/composer.json
+++ b/admin_ui_support/composer.json
@@ -12,7 +12,7 @@
         "bex/behat-screenshot": "^1.2",
         "phpmd/phpmd": "^2.6",
         "phpmetrics/phpmetrics": "^2.3",
-        "drupal/openapi": "1.x-dev"
+        "drupal/openapi": "1.0.0-beta2"
     },
     "require": {
         "php": "^5.5.9 || ^7.0",


### PR DESCRIPTION
In https://github.com/jsdrupal/drupal-admin-ui/pull/216 we added the dependency on OpenAPI dev version. Now the issue we need, https://www.drupal.org/project/openapi/issues/2986679,  is the latest beta2 release.




