### PR TITLE
Rearranged node fields plus added one extra

### DIFF
--- a/src/components/05_pages/NodeForm/UiMetadata.js
+++ b/src/components/05_pages/NodeForm/UiMetadata.js
@@ -8,26 +8,6 @@ const UiMetadata = {
     widget: 'entity_reference_autocomplete',
     constraints: [],
   },
-  created: {
-    widget: 'timestamp_datetime',
-    constraints: [],
-  },
-  field_image: {
-    widget: 'image_image',
-    constraints: [],
-  },
-  field_number_of_servings: {
-    widget: 'number_textfield',
-    constraints: [],
-  },
-  field_difficulty: {
-    widget: 'options_select',
-    constraints: [],
-  },
-  status: {
-    widget: 'boolean_checkbox',
-    constraints: [],
-  },
   field_preparation_time: {
     widget: 'number_textfield',
     constraints: [],
@@ -48,8 +28,32 @@ const UiMetadata = {
       suffix: ' minutes',
     },
   },
+  field_number_of_servings: {
+    widget: 'number_textfield',
+    constraints: [],
+  },
+  field_difficulty: {
+    widget: 'options_select',
+    constraints: [],
+  },
+  field_recipe_category: {
+    widget: 'entity_reference_autocomplete',
+    constraints: [],
+  },
   field_tags: {
     widget: 'entity_reference_autocomplete',
+    constraints: [],
+  },
+  field_image: {
+    widget: 'image_image',
+    constraints: [],
+  },
+  status: {
+    widget: 'boolean_checkbox',
+    constraints: [],
+  },
+  created: {
+    widget: 'timestamp_datetime',
     constraints: [],
   },
 };


### PR DESCRIPTION
## Issue

https://github.com/jsdrupal/drupal-admin-ui/issues/258

## Screenshot / UI changes

Rearranged the admin UI node form fields to look in the same order as Drupal does. Plus there was one field missing i.e Recipe Category. I have added that. (Let me know if this is not required).
![create recipe](https://user-images.githubusercontent.com/10358379/43505688-587bf1e4-9585-11e8-82b3-72f3362c5a48.png)

Also I was not sure where to keep the "Created Date" field. For now, I've kept it at the end of the form.


## Testing instructions

- Navigate to Node Add Recipe page (/node/add/recipe), you should be able to see the same order of fields as Drupal does.
- There are few fields missing (Summary, Ingredients, and Recipe Instruction), a couple of them are editor related. So we can ignore them for now.


