### PR TITLE
Fixed A11y for title Textfield (#178)

### DIFF
--- a/src/components/05_pages/Content/Content.js
+++ b/src/components/05_pages/Content/Content.js
@@ -186,6 +186,7 @@ class Content extends Component {
         <Paper>
           <div className={styles.filters}>
             <TextField
+              inputProps={{ 'aria-label': 'Title' }}
               label="Title"
               placeholder="Title"
               onChange={e => {


### PR DESCRIPTION
## Issue

https://github.com/jsdrupal/drupal-admin-ui/issues/178

Please describe with a few words how to reproduce the problem / test the feature

Screenreaders need at least a aria-label associated with every input element.
This is showing up as a test failure on chrome's lighthouse accessibility tests.


