### PR TITLE
Multi value field initialization

### DIFF
--- a/src/utils/api/schema.js
+++ b/src/utils/api/schema.js
@@ -12,7 +12,7 @@ const createEntity = schema => {
         {},
       );
     case 'array':
-      return [createEntity(schema.items)];
+      return [];
     case 'string':
       return '';
     case 'number':

--- a/src/utils/api/schema.test.js
+++ b/src/utils/api/schema.test.js
@@ -74,3 +74,32 @@ it('should create arrays', () => {
     }),
   ).toEqual(['']);
 });
+
+it('multi value field state is initialized as empty array', () => {
+  expect(
+    createEntity({
+      maxItems: 3,
+      title: 'Image',
+      type: 'object',
+      properties: {
+        data: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              id: {
+                type: 'string',
+                title: 'Resource ID',
+              },
+              type: {
+                type: 'string',
+                title: 'Referenced resource',
+              },
+            },
+            required: ['id', 'type'],
+          },
+        },
+      },
+    }),
+  ).toEqual({ data: [] });
+});

--- a/src/utils/api/schema.test.js
+++ b/src/utils/api/schema.test.js
@@ -72,7 +72,7 @@ it('should create arrays', () => {
         maxLength: 255,
       },
     }),
-  ).toEqual(['']);
+  ).toEqual([]);
 });
 
 it('multi value field state is initialized as empty array', () => {


### PR DESCRIPTION
## Issue

Do not add empty value to multi value field values on initialization also meaning that all widgets should be able to handle empty lists.

