### PR TITLE
Storybook: Resolve errors displayed on the console.(#284)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vfancy",
   "version": "0.1.0",
-  "license" : "MIT",
+  "license": "MIT",
   "private": true,
   "engines": {
     "yarn": ">= 1.6",
@@ -66,6 +66,7 @@
     "eslint-plugin-jsx-a11y": "^6.1.0",
     "eslint-plugin-prettier": "^2.6.0",
     "eslint-plugin-react": "^7.4.0",
+    "fetch-mock": "^6.5.2",
     "jest-junit": "^3.6.0",
     "mkdirp": "^0.5.1",
     "nightwatch": "^0.9.21",

--- a/src/components/02_atoms/FileUpload/FileUpload.stories.js
+++ b/src/components/02_atoms/FileUpload/FileUpload.stories.js
@@ -23,5 +23,11 @@ storiesOf('FileUpload', module).addWithJSX('Default', () => (
     bundle="Article"
     fieldName="upload"
     onFileUpload={onFileUploadAction}
+    multiple={false}
+    remainingUploads={1}
+    inputProps={{
+      file_extensions: 'txt',
+      max_filesize: '1000',
+    }}
   />
 ));

--- a/src/components/02_atoms/Widgets/FileUploadWidget.js
+++ b/src/components/02_atoms/Widgets/FileUploadWidget.js
@@ -123,8 +123,8 @@ const FileUploadWidget = ({
                     const last = Object.keys(value.data).length - 1 === index;
 
                     return (
-                      <Fragment>
-                        <ListItem key={key}>
+                      <Fragment key={key}>
+                        <ListItem>
                           <Image>
                             <img
                               alt={alt || filename}


### PR DESCRIPTION
## Issue

https://github.com/jsdrupal/drupal-admin-ui/issues/284

Please describe with a few words how to reproduce the problem / test the feature

1) yarn run storybook to start the storybook server
2) Open chrome's devtools view the console.
3) Visit the FileUpload widget storybook definitions

see that most of the errors are gone.

We could trap the fetchs to http://localhost:9001/url but I want to keep this PR simple and deal with that in a follow up. 


