### PR TITLE
Remove stray dependancy on fetch-mock

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "eslint-plugin-jsx-a11y": "^6.1.0",
     "eslint-plugin-prettier": "^2.6.0",
     "eslint-plugin-react": "^7.4.0",
-    "fetch-mock": "^6.5.2",
     "jest-junit": "^3.6.0",
     "mkdirp": "^0.5.1",
     "nightwatch": "^0.9.21",


### PR DESCRIPTION
## Issue
Followup to 

https://github.com/jsdrupal/drupal-admin-ui/issues/284

I screwed up ... I was experimenting with trapping and handling fetch requests for storybook widgets
I backed out some code before creating a PR. Unfortunately I did not completely back-out some changes to package.json

It is not appropriate to depend on fetch-mock yet!!!!

Sorry for the distraction.