### PR TITLE
#302 Makes the node/add/x pages accesible

### DIFF
--- a/admin_ui_support/admin_ui_support.routing.yml
+++ b/admin_ui_support/admin_ui_support.routing.yml
@@ -80,6 +80,7 @@ admin_ui_support.node.add:
     _node_add_access: 'node:{node_type}'
   options:
     _node_operation_route: TRUE
+    _admin_related_route: 'node.add'
     parameters:
       node_type:
         with_config_overrides: TRUE

--- a/admin_ui_support/admin_ui_support.routing.yml
+++ b/admin_ui_support/admin_ui_support.routing.yml
@@ -71,3 +71,15 @@ admin_ui_support.node.add_page:
     _node_operation_route: TRUE
   requirements:
     _node_add_access: 'node'
+
+admin_ui_support.node.add:
+  path: '/vfancy/node/add/{node_type}'
+  defaults:
+    _controller: '\Drupal\admin_ui_support\Controller\EmptyController::noop'
+  requirements:
+    _node_add_access: 'node:{node_type}'
+  options:
+    _node_operation_route: TRUE
+    parameters:
+      node_type:
+        with_config_overrides: TRUE


### PR DESCRIPTION
## Issue

https://github.com/jsdrupal/drupal-admin-ui/issues/302

## Testing instructions

- Navigate to the add content page
- Try to add a recipe and get redirected to Seven
- Apply this branch, try again and get the new form




