### PR TITLE
Fix bug in getItemsAsArray().

### DIFF
--- a/src/components/02_atoms/Widgets/FileUploadWidget.js
+++ b/src/components/02_atoms/Widgets/FileUploadWidget.js
@@ -60,7 +60,7 @@ const FileUploadWidget = ({
 
   const items = getItemsAsArray(multiple, value.data)
     // Default schema creates stub entries, which we don't need here.
-    .filter(item => item.file.id);
+    .filter(item => item.id);
   const length = (items && items.length) || 0;
   // maxItems is only set if array, so set to 1 as default.
   const maxItemsCount = multiple ? maxItems || 100000000000 : 1;
@@ -112,12 +112,12 @@ const FileUploadWidget = ({
             <Card>
               <CardContent>
                 <List>
-                  {items.map((data, index) => {
+                  {items.map((item, index) => {
                     const {
-                      file,
+                      id,
                       meta: { alt },
-                    } = data;
-                    const { id, url, filename } = file;
+                      file: { url, filename },
+                    } = item;
                     const last = items.length - 1 === index;
 
                     return (
@@ -141,7 +141,7 @@ const FileUploadWidget = ({
                                 data: setItemById(
                                   multiple,
                                   {
-                                    ...file,
+                                    ...item,
                                     meta: {
                                       alt: event.target.value,
                                     },
@@ -192,15 +192,14 @@ const fileItemSchema = PropTypes.shape({
     id: PropTypes.string.isRequired,
     filename: PropTypes.string.isRequired,
   }),
-  meta: PropTypes.shape({
-    alt: PropTypes.string,
-  }),
 });
-
 FileUploadWidget.propTypes = {
   ...WidgetPropTypes,
   value: PropTypes.shape({
     data: PropTypes.oneOf([PropTypes.arrayOf(fileItemSchema), fileItemSchema]),
+    meta: PropTypes.shape({
+      alt: PropTypes.string,
+    }),
   }),
   inputProps: PropTypes.shape({
     file_extensions: PropTypes.string,

--- a/src/components/02_atoms/Widgets/FileUploadWidget.js
+++ b/src/components/02_atoms/Widgets/FileUploadWidget.js
@@ -60,7 +60,7 @@ const FileUploadWidget = ({
 
   const items = getItemsAsArray(multiple, value.data)
     // Default schema creates stub entries, which we don't need here.
-    .filter(item => item.id);
+    .filter(item => item.file.id);
   const length = (items && items.length) || 0;
   // maxItems is only set if array, so set to 1 as default.
   const maxItemsCount = multiple ? maxItems || 100000000000 : 1;
@@ -112,12 +112,12 @@ const FileUploadWidget = ({
             <Card>
               <CardContent>
                 <List>
-                  {items.map((item, index) => {
+                  {items.map((data, index) => {
                     const {
-                      id,
+                      file,
                       meta: { alt },
-                      file: { url, filename },
-                    } = item;
+                    } = data;
+                    const { id, url, filename } = file;
                     const last = items.length - 1 === index;
 
                     return (
@@ -141,7 +141,7 @@ const FileUploadWidget = ({
                                 data: setItemById(
                                   multiple,
                                   {
-                                    ...item,
+                                    ...file,
                                     meta: {
                                       alt: event.target.value,
                                     },
@@ -192,14 +192,15 @@ const fileItemSchema = PropTypes.shape({
     id: PropTypes.string.isRequired,
     filename: PropTypes.string.isRequired,
   }),
+  meta: PropTypes.shape({
+    alt: PropTypes.string,
+  }),
 });
+
 FileUploadWidget.propTypes = {
   ...WidgetPropTypes,
   value: PropTypes.shape({
     data: PropTypes.oneOf([PropTypes.arrayOf(fileItemSchema), fileItemSchema]),
-    meta: PropTypes.shape({
-      alt: PropTypes.string,
-    }),
   }),
   inputProps: PropTypes.shape({
     file_extensions: PropTypes.string,
@@ -216,7 +217,7 @@ FileUploadWidget.propTypes = {
 };
 
 FileUploadWidget.defaultProps = {
-  value: {},
+  value: { data: { file: {}, meta: {} } },
   inputProps: {
     file_extensions: 'png gif jpg jpeg',
     max_filesize: '2000000',

--- a/src/components/02_atoms/Widgets/Widgets.stories.js
+++ b/src/components/02_atoms/Widgets/Widgets.stories.js
@@ -22,15 +22,20 @@ import DatetimeTimestamp from './DatetimeTimestamp';
 const onChangeAction = action('onChange');
 onChangeAction.toString = () => "action('onChange')";
 
-const fileData = i => ({
-  file: {
-    type: 'file--file',
-    url: `url-${i}`,
-    id: `id-${i}`,
-    filename: `filename-${i}`,
-  },
-  meta: { alt: `This is an alternative(${i}).` },
-});
+const item = i => {
+  const id = `id-${i}`;
+  return {
+    id: { id },
+    file: {
+      type: 'file--file',
+      url: `url-${i}`,
+      id: { id },
+    },
+    meta: {
+      alt: `This is an alternative(${i}).`,
+    },
+  };
+};
 
 storiesOf('Widgets/BooleanCheckbox', module).addWithJSX('Default', () => (
   <BooleanCheckbox
@@ -50,7 +55,7 @@ storiesOf('Widgets/FileUploadWidget/Single File', module).addWithJSX(
       label="File to be uploaded"
       onChange={onChangeAction}
       value={{
-        data: fileData(1),
+        data: item(1),
       }}
       schema={{
         properties: {
@@ -73,7 +78,11 @@ storiesOf('Widgets/FileUploadWidget/Multiple File', module).addWithJSX(
       label="Files to be uploaded"
       onChange={onChangeAction}
       value={{
-        data: [fileData(10), fileData(20), fileData(30)],
+        data: {
+          0: item(10),
+          1: item(20),
+          2: item(30),
+        },
       }}
       schema={{
         maxItems: 10,

--- a/src/components/02_atoms/Widgets/Widgets.stories.js
+++ b/src/components/02_atoms/Widgets/Widgets.stories.js
@@ -22,15 +22,15 @@ import DatetimeTimestamp from './DatetimeTimestamp';
 const onChangeAction = action('onChange');
 onChangeAction.toString = () => "action('onChange')";
 
-const fileData = {
+const fileData = i => ({
   file: {
     type: 'file--file',
-    url: 'url',
-    id: 'id',
-    filename: 'filename',
+    url: `url-${i}`,
+    id: `id-${i}`,
+    filename: `filename-${i}`,
   },
-  meta: { alt: 'This is an alternative.' },
-};
+  meta: { alt: `This is an alternative(${i}).` },
+});
 
 storiesOf('Widgets/BooleanCheckbox', module).addWithJSX('Default', () => (
   <BooleanCheckbox
@@ -39,6 +39,7 @@ storiesOf('Widgets/BooleanCheckbox', module).addWithJSX('Default', () => (
     onChange={onChangeAction}
   />
 ));
+
 storiesOf('Widgets/FileUploadWidget/Single File', module).addWithJSX(
   'Default',
   () => (
@@ -49,9 +50,7 @@ storiesOf('Widgets/FileUploadWidget/Single File', module).addWithJSX(
       label="File to be uploaded"
       onChange={onChangeAction}
       value={{
-        data: {
-          0: fileData,
-        },
+        data: fileData(1),
       }}
       schema={{
         properties: {
@@ -74,11 +73,7 @@ storiesOf('Widgets/FileUploadWidget/Multiple File', module).addWithJSX(
       label="Files to be uploaded"
       onChange={onChangeAction}
       value={{
-        data: {
-          0: fileData,
-          1: fileData,
-          2: fileData,
-        },
+        data: [fileData(10), fileData(20), fileData(30)],
       }}
       schema={{
         maxItems: 10,

--- a/src/utils/api/fieldItem.js
+++ b/src/utils/api/fieldItem.js
@@ -12,7 +12,7 @@ export const setItemById = (multiple, item, items) => {
 
 export const getItemsAsArray = (multiple, items) => {
   if (multiple) {
-    return items;
+    return Object.values(items);
   }
   return [items];
 };


### PR DESCRIPTION
## Issue

https://github.com/jsdrupal/drupal-admin-ui/issues/301

## Screenshot / UI changes

The visual appearance of the storybook entries for the FileUploadWidget are restored to their former glory.

UI changes ... yes

FileUploadWidget: the property value has had its data structures revamped to allow for alternate meta string on a per file basis ( During multiple uploads ).

## Testing instructions

run yarn storybook and see:

the errors are removed.
the FileUploadWidget entries are restored.



