### PR TITLE
(#331) BooleanCheckbox add FormControl.

### DIFF
--- a/src/components/02_atoms/Widgets/BooleanCheckbox.js
+++ b/src/components/02_atoms/Widgets/BooleanCheckbox.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import CheckBox from '@material-ui/core/Checkbox';
+import FormControl from '@material-ui/core/FormControl';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import { css } from 'emotion';
 import WidgetPropTypes from '../../05_pages/NodeForm/WidgetPropTypes';
@@ -11,23 +12,24 @@ const BooleanCheckbox = props => {
   const { onChange, label, value } = props;
 
   return (
-    <FormControlLabel
-      id={`${props.fieldName}-label`}
-      control={
-        <CheckBox
-          id={`${props.fieldName}-cb`}
-          fullWidth
-          onChange={event => onChange(event.target.checked)}
-          margin="normal"
-          value={String(value)}
-        />
-      }
-      label={label}
-      classes={css`
-        ${props.classes} ${styles.widgetRoot};
-      `}
-      required={props.required}
-    />
+    <FormControl fullWidth>
+      <FormControlLabel
+        id={`${props.fieldName}-label`}
+        control={
+          <CheckBox
+            id={`${props.fieldName}-cb`}
+            onChange={event => onChange(event.target.checked)}
+            margin="normal"
+            value={String(value)}
+          />
+        }
+        label={label}
+        classes={css`
+          ${props.classes} ${styles.widgetRoot};
+        `}
+        required={props.required}
+      />
+    </FormControl>
   );
 };
 


### PR DESCRIPTION
## Issue

https://github.com/jsdrupal/drupal-admin-ui/issues/331

We need a FormControl element if we are going to use the fullWidth mechanism.

## Testing instructions

Visit localhost:3000/add/recipe

open Chrome's devtools look at the console log.

With the PR the fullWidth warning as described in the main issue is resolved.

Parsing of the FormControl can now continue and gives more meaningful messages messages about the repeating warning ( which makes  #325  easier to debug/review)  



