### PR TITLE
FileUploadWidget: Invalid prop definition for multiple uploads (#333)

### DIFF
--- a/src/components/02_atoms/Widgets/FileUploadWidget.js
+++ b/src/components/02_atoms/Widgets/FileUploadWidget.js
@@ -262,7 +262,17 @@ class FileUploadWidget extends React.Component {
   }
 }
 
-const fileItemSchema = PropTypes.shape({
+const fileItemMultiplePropType = PropTypes.shape({
+  id: PropTypes.toString.isRequired,
+  file: PropTypes.shape({
+    type: PropTypes.string.isRequired,
+    url: PropTypes.string.isRequired,
+    id: PropTypes.string,
+    filename: PropTypes.string.isRequired,
+  }),
+});
+
+const fileItemPropType = PropTypes.shape({
   file: PropTypes.shape({
     type: PropTypes.string.isRequired,
     url: PropTypes.string.isRequired,
@@ -270,15 +280,18 @@ const fileItemSchema = PropTypes.shape({
     filename: PropTypes.string.isRequired,
   }),
 });
+
 FileUploadWidget.propTypes = {
   ...WidgetPropTypes,
   value: PropTypes.shape({
-    data: PropTypes.oneOfType([
-      PropTypes.arrayOf(fileItemSchema),
-      fileItemSchema,
-    ]),
-    meta: PropTypes.shape({
-      alt: PropTypes.string,
+    data: PropTypes.shape({
+      file: PropTypes.oneOfType([
+        PropTypes.arrayOf(fileItemMultiplePropType),
+        fileItemPropType,
+      ]),
+      meta: PropTypes.shape({
+        alt: PropTypes.string,
+      }),
     }),
   }),
   inputProps: PropTypes.shape({

--- a/src/components/02_atoms/Widgets/FileUploadWidget.js
+++ b/src/components/02_atoms/Widgets/FileUploadWidget.js
@@ -262,23 +262,20 @@ class FileUploadWidget extends React.Component {
   }
 }
 
-const fileItemMultiplePropType = PropTypes.shape({
-  id: PropTypes.toString.isRequired,
-  file: PropTypes.shape({
-    type: PropTypes.string.isRequired,
-    url: PropTypes.string.isRequired,
-    id: PropTypes.string,
-    filename: PropTypes.string.isRequired,
-  }),
+const filePropType = PropTypes.shape({
+  type: PropTypes.string.isRequired,
+  url: PropTypes.string.isRequired,
+  id: PropTypes.string,
+  filename: PropTypes.string.isRequired,
 });
 
-const fileItemPropType = PropTypes.shape({
-  file: PropTypes.shape({
-    type: PropTypes.string.isRequired,
-    url: PropTypes.string.isRequired,
-    id: PropTypes.string.isRequired,
-    filename: PropTypes.string.isRequired,
-  }),
+const fileItemMultiplePropType = PropTypes.shape({
+  id: PropTypes.toString.isRequired,
+  file: filePropType.isRequired,
+});
+
+const fileItemSinglePropType = PropTypes.shape({
+  file: filePropType.isRequired,
 });
 
 FileUploadWidget.propTypes = {
@@ -287,7 +284,7 @@ FileUploadWidget.propTypes = {
     data: PropTypes.shape({
       file: PropTypes.oneOfType([
         PropTypes.arrayOf(fileItemMultiplePropType),
-        fileItemPropType,
+        fileItemSinglePropType,
       ]),
       meta: PropTypes.shape({
         alt: PropTypes.string,


### PR DESCRIPTION
## Issue

https://github.com/jsdrupal/drupal-admin-ui/issues/333

## Testing instructions

This reduces one of the many  warnings that appear on the console log when visiting 

for http://localhost:3000/node/add/recipe
[ The warnings were also visible when looking at the storybook definitions of the FileUploadWidget ]

The parent issue has a description of the bug. But here is a short summary of the solution.

There were two bugs one hiding behind the other

The first bug was a misconception... 

PropTypes.oneOf() incorrectly instead of PropTypes.oneOfType() 

The second bug was just to get the PropTypes to make sense

the id which is required is different in the two distinct cases.



