### PR TITLE
List a11y issue

### DIFF
--- a/src/components/05_pages/AddContent/AddContent.js
+++ b/src/components/05_pages/AddContent/AddContent.js
@@ -11,6 +11,10 @@ import ListItemText from '@material-ui/core/ListItemText';
 import PageTitle from '../../02_atoms/PageTitle';
 
 const styles = {
+  menuLink: css`
+    display: inherit;
+    text-decoration: inherit;
+  `,
   root: css`
     margin-bottom: 50px;
   `,
@@ -35,8 +39,8 @@ export default class extends Component {
       <Paper>
         <List data-nightwatch="node-type-list">
           {Object.keys(this.props.contentTypes).map(contentType => (
-            <ListItem button component="li" key={`node-add-${contentType}`}>
-              <Link to={`/node/add/${contentType}`}>
+            <ListItem component="li" key={`node-add-${contentType}`}>
+              <Link className={styles.menuLink} to={`/node/add/${contentType}`}>
                 <ListItemText
                   primary={this.props.contentTypes[contentType].name}
                   secondary={

--- a/src/components/05_pages/AddContent/AddContent.js
+++ b/src/components/05_pages/AddContent/AddContent.js
@@ -35,20 +35,17 @@ export default class extends Component {
       <Paper>
         <List data-nightwatch="node-type-list">
           {Object.keys(this.props.contentTypes).map(contentType => (
-            <ListItem
-              button
-              component={Link}
-              to={`/node/add/${contentType}`}
-              key={`node-add-${contentType}`}
-            >
-              <ListItemText
-                primary={this.props.contentTypes[contentType].name}
-                secondary={
-                  <Markup
-                    content={this.props.contentTypes[contentType].description}
-                  />
-                }
-              />
+            <ListItem button component="li" key={`node-add-${contentType}`}>
+              <Link to={`/node/add/${contentType}`}>
+                <ListItemText
+                  primary={this.props.contentTypes[contentType].name}
+                  secondary={
+                    <Markup
+                      content={this.props.contentTypes[contentType].description}
+                    />
+                  }
+                />
+              </Link>
             </ListItem>
           ))}
         </List>

--- a/src/tests/Nightwatch/Tests/AddContent.js
+++ b/src/tests/Nightwatch/Tests/AddContent.js
@@ -8,19 +8,19 @@ module.exports = {
 
     browser.expect
       .element(
-        '[data-nightwatch="node-type-list"] a:nth-child(1) span:first-child',
+        '[data-nightwatch="node-type-list"] li:nth-child(1) a span:first-child',
       )
       .text.to.equal('Article');
 
     browser.expect
       .element(
-        '[data-nightwatch="node-type-list"] a:nth-child(2) span:first-child',
+        '[data-nightwatch="node-type-list"] li:nth-child(2) a span:first-child',
       )
       .text.to.equal('Basic page');
 
     browser.expect
       .element(
-        '[data-nightwatch="node-type-list"] a:nth-child(3) span:first-child',
+        '[data-nightwatch="node-type-list"] li:nth-child(3) a span:first-child',
       )
       .text.to.equal('Recipe');
 


### PR DESCRIPTION
## Issue

https://github.com/jsdrupal/drupal-admin-ui/issues/342

## Testing instructions

as per instruction on the home page enable aXe with : -

REACT_APP_AXE=true yarn start

visit http://localhost:3000/node/add/recipe

in the parent issue I detailed a axe report that highlights a issue with the DOM structure which confounds screen readers.

With this PR applied the aXe warnings go away.

Please note a small amount of css is needed to bypass a underline text issue common to many  LINK elements.




