### PR TITLE
Storybook: OptionsSelect 'allowed_values' needs updating (#364)

### DIFF
--- a/src/components/02_atoms/Widgets/Widgets.stories.js
+++ b/src/components/02_atoms/Widgets/Widgets.stories.js
@@ -117,8 +117,17 @@ storiesOf('Widgets/NumberTextfield', module).addWithJSX('Default', () => (
 
 storiesOf('Widgets/OptionsSelect', module).addWithJSX('Default', () => (
   <OptionsSelect
-    fieldName="option"
     helpText={text('OptionsSelect:helpText', 'Help text.')}
+    fieldName="option"
+    inputProps={object('OptionsSelect:inputProps', {
+      allowed_values: {
+        one: 'One',
+        two: 'Two',
+        three: 'Three',
+        four: 'Four',
+      },
+      allowed_values_function: '',
+    })}
     label={text('OptionsSelect:label', 'A Simple Label')}
     onChange={onChangeAction}
     schema={object('OptionsSelect: schema', {


### PR DESCRIPTION
## Issue

https://github.com/jsdrupal/drupal-admin-ui/issues/364

a) I have put OptionsSelect in alphabetical order.
b) I  have added a inputProps object ... a required object.

## Testing instructions

a) Start the storbook server with 

yarn storybook

b) visit

http://localhost:9001/

open the widgets tab, select OptionsSelect

see that the page no longer shows errors.





