### PR TITLE
Make onSave specific to the action entity form is tied for

### DIFF
--- a/src/components/05_pages/NodeAddForm/index.js
+++ b/src/components/05_pages/NodeAddForm/index.js
@@ -1,19 +1,43 @@
 import React, { Fragment } from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import LoadingBar from 'react-redux-loading-bar';
 import NodeForm from '../NodeForm';
 import PageTitle from '../../02_atoms/PageTitle/PageTitle';
+import { contentAdd } from '../../../actions/content';
 
-const NodeAddForm = props => (
-  <Fragment>
-    <PageTitle>Create {props.bundle}</PageTitle>
-    <LoadingBar />
-    <NodeForm {...props} />
-  </Fragment>
-);
+class NodeAddForm extends React.Component {
+  constructor() {
+    super();
+    this.onSave = this.onSave.bind(this);
+  }
+
+  onSave(entity) {
+    const data = {
+      ...entity,
+      type: `${this.props.entityTypeId}--${this.props.bundle}`,
+    };
+    this.props.contentAdd(data);
+  };
+
+  render() {
+    return (
+      <Fragment>
+        <PageTitle>Create {this.props.bundle}</PageTitle>
+        <LoadingBar/>
+        <NodeForm {...this.props} onSave={this.onSave} />
+      </Fragment>
+    );
+  }
+}
 
 NodeAddForm.propTypes = {
   bundle: PropTypes.string.isRequired,
 };
 
-export default NodeAddForm;
+export default connect(
+  null,
+  {
+    contentAdd,
+  },
+)(NodeAddForm);

--- a/src/components/05_pages/NodeAddForm/index.js
+++ b/src/components/05_pages/NodeAddForm/index.js
@@ -7,18 +7,13 @@ import PageTitle from '../../02_atoms/PageTitle/PageTitle';
 import { contentAdd } from '../../../actions/content';
 
 class NodeAddForm extends React.Component {
-  constructor() {
-    super();
-    this.onSave = this.onSave.bind(this);
-  }
-
-  onSave(entity) {
+  onSave = entity => {
     const data = {
       ...entity,
       type: `${this.props.entityTypeId}--${this.props.bundle}`,
     };
     this.props.contentAdd(data);
-  }
+  };
 
   render() {
     return (

--- a/src/components/05_pages/NodeAddForm/index.js
+++ b/src/components/05_pages/NodeAddForm/index.js
@@ -18,13 +18,13 @@ class NodeAddForm extends React.Component {
       type: `${this.props.entityTypeId}--${this.props.bundle}`,
     };
     this.props.contentAdd(data);
-  };
+  }
 
   render() {
     return (
       <Fragment>
         <PageTitle>Create {this.props.bundle}</PageTitle>
-        <LoadingBar/>
+        <LoadingBar />
         <NodeForm {...this.props} onSave={this.onSave} />
       </Fragment>
     );
@@ -33,6 +33,8 @@ class NodeAddForm extends React.Component {
 
 NodeAddForm.propTypes = {
   bundle: PropTypes.string.isRequired,
+  contentAdd: PropTypes.func.isRequired,
+  entityTypeId: PropTypes.string.isRequired,
 };
 
 export default connect(

--- a/src/components/05_pages/NodeEditForm/index.js
+++ b/src/components/05_pages/NodeEditForm/index.js
@@ -6,6 +6,7 @@ import { css } from 'emotion';
 import NodeForm from '../NodeForm';
 import { requestSingleContent } from '../../../actions/content';
 import PageTitle from '../../02_atoms/PageTitle/PageTitle';
+import { contentAdd } from '../../../actions/content';
 
 let styles;
 
@@ -13,6 +14,15 @@ class NodeEditForm extends React.Component {
   componentDidMount() {
     this.props.requestSingleContent(this.props.nid);
   }
+
+  onSave(entity) {
+    const data = {
+      ...entity,
+      type: `${this.props.entityTypeId}--${this.props.bundle}`,
+    };
+    // @todo this should be changed to edit specific action.
+    this.props.contentAdd(data);
+  };
 
   render() {
     const { entity } = this.props;
@@ -35,6 +45,7 @@ class NodeEditForm extends React.Component {
               {...this.props}
               bundle={bundle}
               entity={{ data: entity }}
+              onSave={this.onSave}
             />
           )}
         </Fragment>
@@ -70,5 +81,6 @@ export default connect(
   }),
   {
     requestSingleContent,
+    contentAdd,
   },
 )(NodeEditForm);

--- a/src/components/05_pages/NodeEditForm/index.js
+++ b/src/components/05_pages/NodeEditForm/index.js
@@ -14,14 +14,14 @@ class NodeEditForm extends React.Component {
     this.props.requestSingleContent(this.props.nid);
   }
 
-  onSave(entity) {
+  onSave = entity => {
     const data = {
       ...entity,
       type: `${this.props.entityTypeId}--${this.props.bundle}`,
     };
     // @todo this should be changed to edit specific action.
     this.props.contentAdd(data);
-  }
+  };
 
   render() {
     const { entity } = this.props;

--- a/src/components/05_pages/NodeEditForm/index.js
+++ b/src/components/05_pages/NodeEditForm/index.js
@@ -4,9 +4,8 @@ import LoadingBar from 'react-redux-loading-bar';
 import PropTypes from 'prop-types';
 import { css } from 'emotion';
 import NodeForm from '../NodeForm';
-import { requestSingleContent } from '../../../actions/content';
+import { contentAdd, requestSingleContent } from '../../../actions/content';
 import PageTitle from '../../02_atoms/PageTitle/PageTitle';
-import { contentAdd } from '../../../actions/content';
 
 let styles;
 
@@ -22,7 +21,7 @@ class NodeEditForm extends React.Component {
     };
     // @todo this should be changed to edit specific action.
     this.props.contentAdd(data);
-  };
+  }
 
   render() {
     const { entity } = this.props;
@@ -62,6 +61,9 @@ NodeEditForm.defaultProps = {
 NodeEditForm.propTypes = {
   nid: PropTypes.string.isRequired,
   requestSingleContent: PropTypes.func.isRequired,
+  contentAdd: PropTypes.func.isRequired,
+  entityTypeId: PropTypes.string.isRequired,
+  bundle: PropTypes.string.isRequired,
   entity: PropTypes.shape({
     attributes: PropTypes.shape({
       title: PropTypes.string.isRequired,

--- a/src/components/05_pages/NodeForm/index.js
+++ b/src/components/05_pages/NodeForm/index.js
@@ -28,7 +28,7 @@ class NodeForm extends React.Component {
         PropTypes.instanceOf(React.Component),
       ]).isRequired,
     ).isRequired,
-    contentAdd: PropTypes.func.isRequired,
+    onSave: PropTypes.func.isRequired,
     entityTypeId: PropTypes.string.isRequired,
     bundle: PropTypes.string.isRequired,
     requestSchema: PropTypes.func.isRequired,
@@ -106,7 +106,7 @@ class NodeForm extends React.Component {
 
   onSave = () => {
     this.props.onSave(this.state.entity.data);
-  }
+  };
 
   onRelationshipChange = fieldName => data => {
     // Support widgets with multiple cardinality.

--- a/src/components/05_pages/NodeForm/index.js
+++ b/src/components/05_pages/NodeForm/index.js
@@ -9,7 +9,6 @@ import Button from '@material-ui/core/Button';
 
 import SchemaPropType from './SchemaPropType';
 
-import { contentAdd } from '../../../actions/content';
 import { requestSchema, requestUiSchema } from '../../../actions/schema';
 
 import {
@@ -105,6 +104,10 @@ class NodeForm extends React.Component {
     }));
   };
 
+  onSave = () => {
+    this.props.onSave(this.state.entity.data);
+  }
+
   onRelationshipChange = fieldName => data => {
     // Support widgets with multiple cardinality.
     let fieldData;
@@ -126,17 +129,6 @@ class NodeForm extends React.Component {
         },
       },
     }));
-  };
-
-  onSave = () => {
-    // @todo Remove in https://github.com/jsdrupal/drupal-admin-ui/issues/245
-    const { data: entity } = this.state.entity;
-
-    const data = {
-      ...entity,
-      type: `${this.props.entityTypeId}--${this.props.bundle}`,
-    };
-    this.props.contentAdd(data);
   };
 
   getSchemaInfo = (schema, fieldName) =>
@@ -240,6 +232,5 @@ export default connect(
   {
     requestSchema,
     requestUiSchema,
-    contentAdd,
   },
 )(NodeForm);


### PR DESCRIPTION
Move onSave from the NodeForm to it's parent so that changing it separately for entity creation and editing is possible.
