### PR TITLE
Make type check in PageTitle component more accurate

### DIFF
--- a/src/components/02_atoms/PageTitle/PageTitle.js
+++ b/src/components/02_atoms/PageTitle/PageTitle.js
@@ -38,7 +38,7 @@ const reducePropsToState = propsList => {
  */
 const handleStateChangeOnClient = title => {
   document.title = (Array.isArray(title) ? title : [title])
-    .map(e => (e && e instanceof String ? e.trim() : ''))
+    .map(e => (e && typeof e === 'string' ? e.trim() : ''))
     .join(' ');
 };
 


### PR DESCRIPTION
## Issue

Sometimes the document title wasn't set because of an overly strict type check. This should improve the situation and make the title visible.




