### PR TITLE
Native HTML replaced with Material Ui and paragraph wrapper removed.

### DIFF
--- a/src/components/05_pages/Content/ConfirmationDialog.js
+++ b/src/components/05_pages/Content/ConfirmationDialog.js
@@ -6,9 +6,11 @@ import Button from '@material-ui/core/Button';
 import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
-import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import Slide from '@material-ui/core/Slide';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemText from '@material-ui/core/ListItemText';
 
 const styles = {
   dialogActionName: css`
@@ -37,22 +39,22 @@ const ConfirmationDialog = ({
     >
       <DialogTitle>
         Are you sure you want to apply the &quot;
-        <span className={styles.dialogActionName}>{actionLabel}</span>&quot;
-        action to these content items?
+        <span className={styles.dialogActionName}>{actionLabel}</span>
+        &quot; action to these content items?
       </DialogTitle>
       <DialogContent>
-        <DialogContentText>
-          <ul>
-            {contentList
-              .filter(({ attributes: { nid } }) =>
-                Object.keys(checked).includes(`${nid}`),
-              )
-              .map(({ attributes: { title, nid } }) => (
-                <li key={nid}>{title}</li>
-              ))}
-          </ul>
-          This action cannot be undone.
-        </DialogContentText>
+        <List>
+          {contentList
+            .filter(({ attributes: { nid } }) =>
+              Object.keys(checked).includes(`${nid}`),
+            )
+            .map(({ attributes: { title, nid } }) => (
+              <ListItem key={nid}>
+                <ListItemText>{`- ${title}`}</ListItemText>
+              </ListItem>
+            ))}
+        </List>
+        This action cannot be undone.
       </DialogContent>
       <DialogActions>
         <Button


### PR DESCRIPTION
## Issue

https://github.com/jsdrupal/drupal-admin-ui/issues/416

## Screenshot / UI changes
<img width="603" alt="screen shot 2018-08-27 at 2 07 46 pm" src="https://user-images.githubusercontent.com/13252288/44650120-5efc0a80-aa03-11e8-98a4-39d78f2f5eef.png">


Native list elements replaced with material-ui elements and Appropriate nesting added.

## Testing instructions

1. Go to `/`
2. Select a couple of checkboxes.
3. The warning message must not appear.




