### PR TITLE
issue-421: Confirmation dialog text styling fixed.

### DIFF
--- a/src/components/05_pages/Content/ConfirmationDialog.js
+++ b/src/components/05_pages/Content/ConfirmationDialog.js
@@ -11,10 +11,15 @@ import Slide from '@material-ui/core/Slide';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
+import Typography from '@material-ui/core/Typography';
 
 const styles = {
   dialogActionName: css`
     text-transform: lowercase;
+  `,
+  listItemText: css`
+    list-style-type: disc;
+    display: list-item;
   `,
 };
 
@@ -50,11 +55,13 @@ const ConfirmationDialog = ({
             )
             .map(({ attributes: { title, nid } }) => (
               <ListItem key={nid}>
-                <ListItemText>{`- ${title}`}</ListItemText>
+                <ListItemText className={styles.listItemText}>
+                  {`${title}`}
+                </ListItemText>
               </ListItem>
             ))}
         </List>
-        This action cannot be undone.
+        <Typography>This action cannot be undone.</Typography>
       </DialogContent>
       <DialogActions>
         <Button


### PR DESCRIPTION
## Issue

https://github.com/jsdrupal/drupal-admin-ui/issues/421

## Screenshot / UI changes

<img width="984" alt="screen shot 2018-08-29 at 12 36 29 pm" src="https://user-images.githubusercontent.com/25002064/44771277-30f40300-ab88-11e8-9c3a-1f9ca237d1a3.png">
Changed the list style to bullets and removed '-' from list items in confirmation dialog.

## Testing instructions

1. Select the content on which action needs to be performed.
2. On Actions tab, select any action e.g : Delete content.
3. Click Apply button.
4. Confirmation dialog list contains bullets instead of '-'.




