### PR TITLE
issue-437: TypeError resolved on widgets.

### DIFF
--- a/src/components/05_pages/NodeForm/index.js
+++ b/src/components/05_pages/NodeForm/index.js
@@ -29,6 +29,11 @@ class NodeForm extends React.Component {
       PropTypes.oneOfType([
         PropTypes.func,
         PropTypes.instanceOf(React.Component),
+        PropTypes.shape({
+          options_select: PropTypes.shape({
+            component: PropTypes.instanceOf(React.Component),
+          }),
+        }),
       ]).isRequired,
     ).isRequired,
     onSave: PropTypes.func.isRequired,


### PR DESCRIPTION
## Issue

https://github.com/jsdrupal/drupal-admin-ui/issues/437

## Testing instructions

1. Go to the URL : /node/add/recipe.
2. Check the console. The TypeError related to widgets.option_select on NodeForm is not reproducible now.




