### PR TITLE
Issue-442: Fixed Error messages not rendering properly for File upload widget.

### DIFF
--- a/src/components/02_atoms/FileUpload/FileUpload.js
+++ b/src/components/02_atoms/FileUpload/FileUpload.js
@@ -41,6 +41,7 @@ const marginTop = {
 
 const error = {
   color: 'red',
+  paddingLeft: 0,
 };
 
 class FileUpload extends Component {


### PR DESCRIPTION
#442 

## Screenshot / UI changes

![screen shot 2018-08-30 at 5 22 59 pm](https://user-images.githubusercontent.com/15143023/44850058-adb2da00-ac79-11e8-97cf-54274d288d8e.png)

## Testing instructions
Upload file format which is not acceptable and checks the Error message theme.
