### PR TITLE
Cleanup how route params are handled.

### DIFF
--- a/src/components/05_pages/NodeAddForm/index.js
+++ b/src/components/05_pages/NodeAddForm/index.js
@@ -83,10 +83,19 @@ const extractRestorableEntity = (state, bundle) =>
   state.content.restorableContentAddByBundle[bundle];
 
 export default connect(
-  (state, { bundle, entityTypeId }) => ({
-    schema: state.schema.schema[`${entityTypeId}--${bundle}`],
+  (
+    state,
+    {
+      match: {
+        params: { bundle },
+      },
+    },
+  ) => ({
+    schema: state.schema.schema[`node--${bundle}`],
     restorableEntity: extractRestorableEntity(state, bundle),
     user: state.content.user,
+    entityTypeId: 'node',
+    bundle,
   }),
   {
     contentAdd,

--- a/src/components/05_pages/NodeEditForm/index.js
+++ b/src/components/05_pages/NodeEditForm/index.js
@@ -98,11 +98,20 @@ const extractRestorableEntity = (state, entity) => {
 };
 
 export default connect(
-  (state, props) => {
-    const entity = state.content.contentByNid[props.nid];
+  (
+    state,
+    {
+      match: {
+        params: { nid },
+      },
+    },
+  ) => {
+    const entity = state.content.contentByNid[nid];
     return {
-      entity: state.content.contentByNid[props.nid],
+      entity: state.content.contentByNid[nid],
       restorableEntity: entity && extractRestorableEntity(state, entity),
+      entityTypeId: 'node',
+      nid,
     };
   },
   {

--- a/src/components/05_pages/NodeForm/index.js
+++ b/src/components/05_pages/NodeForm/index.js
@@ -20,17 +20,13 @@ import { setErrorMessage } from '../../../actions/application';
 
 import { createUISchema, sortUISchemaFields } from '../../../utils/api/schema';
 
+import widgets from './Widgets';
+
 let styles;
 
 class NodeForm extends React.Component {
   static propTypes = {
     schema: PropTypes.oneOfType([SchemaPropType, PropTypes.bool]),
-    widgets: PropTypes.objectOf(
-      PropTypes.oneOfType([
-        PropTypes.func,
-        PropTypes.instanceOf(React.Component),
-      ]).isRequired,
-    ).isRequired,
     onSave: PropTypes.func.isRequired,
     entityTypeId: PropTypes.string.isRequired,
     bundle: PropTypes.string.isRequired,
@@ -305,7 +301,7 @@ class NodeForm extends React.Component {
           this.props.uiSchema.fieldSchema,
           this.props.uiSchema.formDisplaySchema,
           this.props.uiSchema.fieldStorageConfig,
-          this.props.widgets,
+          widgets,
         ),
         ['promote', 'status', 'sticky', 'uid', 'created'],
       );

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,11 +1,9 @@
-import React from 'react';
 import AddContent from './components/05_pages/AddContent';
 import Content from './components/05_pages/Content/Content';
 import Permissions from './components/05_pages/Permissions/Permissions';
 import Roles from './components/05_pages/Roles';
 import Dblog from './components/05_pages/Reports/Dblog';
 import NodeEditForm from './components/05_pages/NodeEditForm';
-import widgets from './components/05_pages/NodeForm/Widgets';
 import NodeAddForm from './components/05_pages/NodeAddForm';
 
 // @todo Share this with Drupal
@@ -15,22 +13,8 @@ const routes = {
   '/admin/people/roles': Roles,
   '/admin/reports/dblog': Dblog,
   '/node/add': AddContent,
-  // eslint-disable-next-line react/prop-types
-  '/node/:nid/edit': ({ match }) => (
-    <NodeEditForm
-      entityTypeId="node"
-      widgets={widgets}
-      nid={match.params.nid}
-    />
-  ),
-  // eslint-disable-next-line react/prop-types
-  '/node/add/:bundle': ({ match }) => (
-    <NodeAddForm
-      entityTypeId="node"
-      bundle={match.params.bundle}
-      widgets={widgets}
-    />
-  ),
+  '/node/:nid/edit': NodeEditForm,
+  '/node/add/:bundle': NodeAddForm,
 };
 
 export default routes;


### PR DESCRIPTION
## Issue

Routes/Components that need props from React Router are handled a bit different than those that do not. There is no reason for this. This moves the route matching params logic to either `NodeEdit` or `NodeAdd` instead of the actual router.  





