### PR TITLE
Use saga/effects all instead of Promise.all()

### DIFF
--- a/src/actions/schema.js
+++ b/src/actions/schema.js
@@ -1,4 +1,4 @@
-import { put, call, takeLatest } from 'redux-saga/effects';
+import { put, call, takeLatest, all } from 'redux-saga/effects';
 import {
   showLoading,
   hideLoading,
@@ -25,7 +25,7 @@ function* loadUiSchema(action) {
       { data: fieldSchema },
       { data: formDisplaySchema },
       { data: fieldStorageConfig },
-    ] = yield Promise.all([
+    ] = yield all([
       api('field_schema', {
         queryString: {
           filter: { entity_type: entityTypeId, bundle },


### PR DESCRIPTION
## Issue

We're currently using `Promise.all()` instead of `all([])` from `redux-saga`. https://redux-saga.js.org/docs/api/#alleffects---parallel-effects

## Testing instructions

- Ensure schema is still fetched correctly.



