### PR TITLE
Two clicks issue resolved for MultipleFields

### DIFF
--- a/src/components/02_atoms/MultipleFields/MultipleFields.js
+++ b/src/components/02_atoms/MultipleFields/MultipleFields.js
@@ -144,7 +144,8 @@ class MultipleFields extends Component {
    */
   addAnotherItem = () => {
     const { value, onChange } = this.props;
-    const newValue = [...value, ''];
+    const updatedValue = (value.length && value) || [''];
+    const newValue = [...updatedValue, ''];
     this.setState(
       {
         newItemAdded: true,


### PR DESCRIPTION
## Issue

https://github.com/jsdrupal/drupal-admin-ui/issues/480

Local data i.e usedValues removed as it was causing problems in keeping a synched redux state. There were two sources of truth one is `usedValues` and `values`

**I have removed the local variable `usedValues`** and using only `values`.  With this, the actual changes in the widget would be directly reflected in the redux state thus keeping a single source of truth as `values`



