### PR TITLE
requestShema PropType removed from NodeForm.

### DIFF
--- a/src/components/05_pages/NodeForm/index.js
+++ b/src/components/05_pages/NodeForm/index.js
@@ -30,7 +30,6 @@ class NodeForm extends React.Component {
     onSave: PropTypes.func.isRequired,
     entityTypeId: PropTypes.string.isRequired,
     bundle: PropTypes.string.isRequired,
-    requestSchema: PropTypes.func.isRequired,
     requestUiSchema: PropTypes.func.isRequired,
     uiSchema: PropTypes.oneOfType([
       PropTypes.shape({


### PR DESCRIPTION
## Issue

https://github.com/jsdrupal/drupal-admin-ui/issues/484


requestShema PropType removed from NodeForm as it is not required.

