### PR TITLE
Add route override for entity.node.edit_form

### DIFF
--- a/admin_ui_support/admin_ui_support.routing.yml
+++ b/admin_ui_support/admin_ui_support.routing.yml
@@ -84,3 +84,11 @@ admin_ui_support.node.add:
     parameters:
       node_type:
         with_config_overrides: TRUE
+
+admin_ui_support.node.edit:
+  path: '/vfancy/node/{node}/edit'
+  defaults:
+    _controller: '\Drupal\admin_ui_support\Controller\EmptyController::noop'
+  options:
+    _node_operation_route: TRUE
+    _admin_related_route: 'entity.node.edit_form'


### PR DESCRIPTION
## Issue

https://github.com/jsdrupal/drupal-admin-ui/issues/493

## Screenshot / UI changes

When editing node from node view it now routes to correct vfancy route

## Testing instructions

View an existing node and then click edit, it will take you to the Drupal 8.x node edit form. Then apply pull request and it will redirect to vfancy entity.edit_form 




