### PR TITLE
Permission: "disabled" must be a boolean #522

### DIFF
--- a/packages/admin-ui/src/components/05_pages/Permissions/Permissions.js
+++ b/packages/admin-ui/src/components/05_pages/Permissions/Permissions.js
@@ -154,7 +154,7 @@ const Permissions = class Permissions extends Component {
               ...roles.map(({ attributes }, index) => [
                 `td-${providerMachineName}-${permission.title}-${index}-cb`,
                 attributes.is_admin && attributes.id === 'administrator' ? (
-                  <input type="checkbox" checked disabled="disabled" />
+                  <input type="checkbox" checked disabled={true} />
                 ) : (
                   <input
                     type="checkbox"

--- a/packages/admin-ui/src/components/05_pages/Permissions/Permissions.js
+++ b/packages/admin-ui/src/components/05_pages/Permissions/Permissions.js
@@ -154,7 +154,7 @@ const Permissions = class Permissions extends Component {
               ...roles.map(({ attributes }, index) => [
                 `td-${providerMachineName}-${permission.title}-${index}-cb`,
                 attributes.is_admin && attributes.id === 'administrator' ? (
-                  <input type="checkbox" checked disabled={true} />
+                  <input type="checkbox" checked disabled />
                 ) : (
                   <input
                     type="checkbox"


### PR DESCRIPTION
## Issue

https://github.com/jsdrupal/drupal-admin-ui/issues/522

This is a very very minor   issue.

I am using a stricter linter tool, as I slowly convert this project to typescript.

This is just an isolated boolean type mismatch picked up by the new tooling.
( see the parent issue. for a detailed explanation ) 




