### PR TITLE
Stringified state

### DIFF
--- a/packages/admin-ui/src/App.js
+++ b/packages/admin-ui/src/App.js
@@ -43,8 +43,8 @@ export const localStorageName = 'drupalAdminUiReduxState';
  * Restore from local storage.
  */
 const restoreState = () => {
-  const storedState;
-  const stringifiedState;
+  let storedState;
+  let stringifiedState;
   if (typeof window === 'object') {
     try {
       // Test for Safari private browsing mode. This will throw an error if it can't set an item.

--- a/packages/admin-ui/src/App.js
+++ b/packages/admin-ui/src/App.js
@@ -44,11 +44,12 @@ export const localStorageName = 'drupalAdminUiReduxState';
  */
 const restoreState = () => {
   let storedState = {};
+  let stringifiedState = '';
   if (typeof window === 'object') {
     try {
       // Test for Safari private browsing mode. This will throw an error if it can't set an item.
       localStorage.setItem('localStorageTest', true);
-      storedState = localStorage.getItem(localStorageName) || '{}';
+      stringifiedState = localStorage.getItem(localStorageName) || '';
     } catch (e) {
       // In case like Safari private browing mode we don't support any restoring.
       // Also note: enzyme has window but no Cookie set.
@@ -60,7 +61,7 @@ const restoreState = () => {
   }
 
   try {
-    storedState = JSON.parse(storedState);
+    storedState = JSON.parse(stringifiedState);
   } catch (e) {
     storedState = {};
   }

--- a/packages/admin-ui/src/App.js
+++ b/packages/admin-ui/src/App.js
@@ -43,8 +43,8 @@ export const localStorageName = 'drupalAdminUiReduxState';
  * Restore from local storage.
  */
 const restoreState = () => {
-  let storedState = {};
-  let stringifiedState = '';
+  const storedState;
+  const stringifiedState;
   if (typeof window === 'object') {
     try {
       // Test for Safari private browsing mode. This will throw an error if it can't set an item.
@@ -53,10 +53,10 @@ const restoreState = () => {
     } catch (e) {
       // In case like Safari private browing mode we don't support any restoring.
       // Also note: enzyme has window but no Cookie set.
-      storedState =
+      stringifiedState =
         (window.Cookie &&
           decodeURIComponent(window.Cookie.get(localStorageName))) ||
-        {};
+        '';
     }
   }
 


### PR DESCRIPTION
## Issue

https://github.com/jsdrupal/drupal-admin-ui/issues/527

This is just a minor issue 

Here is a summary of the originating issue.

As I work on the typescript branch -- the lifecycle of the storedState  variable is driving the linter crazy.

It is initialized as a object, assigned a string, and the converted back to a object as part of a JSON.parse() 

The solution is to split the variable into two.

 


