### PR TITLE
Move from es5 to es6 to support ENUMs and MAPs. #552

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,6 +5,12 @@
     "plugin:jsx-a11y/recommended"
   ],
   "parser": "babel-eslint",
+  "parserOptions": {
+      "ecmaVersion": 6,
+      "ecmaFeatures": {
+          "jsx": true
+      }
+  },
   "env": {
     "browser": true,
     "es6": true,


### PR DESCRIPTION
## Issue

https://github.com/jsdrupal/drupal-admin-ui/issues/552

I want to use ENUMs in a upcoming PR - #538 Make MessageSeverity constants an ENUM

but first we need to move the ES6

Here is a quote from the eslint documentation showing that the current default is es5

https://eslint.org/docs/2.0.0/user-guide/configuring

ecmaVersion - set to 3, 5 (default), or 6 to specify the version of ECMAScript you want to use.





