### PR TITLE
devify .env has moved #532

### DIFF
--- a/demo/composer.json
+++ b/demo/composer.json
@@ -45,7 +45,7 @@
         ],
         "devify": [
             "git clone https://github.com/jsdrupal/drupal-admin-ui",
-            "cp drupal-admin-ui/.env drupal-admin-ui/.env.local",
+            "cp drupal-admin-ui/packages/admin-ui/.env drupal-admin-ui/packages/admin-ui/.env.local",
             "cd drupal-admin-ui && yarn install",
             "rm -rf docroot/vfancy",
             "ln -s ../drupal-admin-ui/build docroot/vfancy",


### PR DESCRIPTION
## Issue

https://github.com/jsdrupal/drupal-admin-ui/issues/532

When the workspace modifications were committed the location of .env changes 

the devify command did not account for this ... 

I am just restoring functionality.



