### PR TITLE
AddContent: Replace div with fragment

### DIFF
--- a/packages/admin-ui/src/components/05_pages/AddContent/AddContent.js
+++ b/packages/admin-ui/src/components/05_pages/AddContent/AddContent.js
@@ -47,6 +47,7 @@ export default class extends Component {
                   secondary={
                     <Markup
                       content={this.props.contentTypes[contentType].description}
+                      tagName="fragment"
                     />
                   }
                 />


### PR DESCRIPTION
## Issue

https://github.com/jsdrupal/drupal-admin-ui/issues/555

The parent issue identifier that typescript files were not being linted. Another PR rename files containing typescript to AddContent.test.js and  AddContent.test.jsx 

This PR now fixes one of the outstanding lint errors 

Markup is wrapped in a ListItemText element and so as we sanitize it is inappropriate to use Markup's default of a div as an internal wrapper.

https://github.com/jsdrupal/drupal-admin-ui/issues/555#issuecomment-441188250

Here is the lint warning

> Warning: validateDOMNesting(...): cannot appear as a descendant of <p>.


looking at the valid values for tagName in  Markup -- "span" or "fragment" are the only possibilities 

fragment has the advantage of dissolving into nothing. 




