### PR TITLE
Run composer test as the current user

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
       - start-project
       - run:
           name: Run tests
-          command: docker exec -it drupal_admin_ui_drupal composer test
+          command: docker exec -u $(id -u):$(id -g) -it drupal_admin_ui_drupal composer test
       - store_test_results:
           path: ~/project/packages/admin-ui/reports
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ commands:
           name: Start Docker
           command: |
             set -x
-            UID=$(id -u) GID=$(id -g) docker-compose build
+            uid=$(id -u) gid=$(id -g) docker-compose build
             docker-compose up -d
             ./.docker/check-ready.sh
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ commands:
           name: Start Docker
           command: |
             set -x
-            docker-compose build
+            UID=$(id -u) GID=$(id -g) docker-compose build
             docker-compose up -d
             ./.docker/check-ready.sh
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
       - start-project
       - run:
           name: Run tests
-          command: docker exec -it drupal_admin_ui_drupal su -m apache -s /bin/sh -c "composer test"
+          command: docker exec -it drupal_admin_ui_drupal composer test
       - store_test_results:
           path: ~/project/packages/admin-ui/reports
 

--- a/.docker/check-ready.sh
+++ b/.docker/check-ready.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-until docker exec -it drupal_admin_ui_drupal test -e ~/.drupal-installation-complete && docker exec -it drupal_admin_ui_node test -e /root/.yarn-build-complete
+until docker exec -it drupal_admin_ui_drupal test -e ~/.drupal-installation-complete && docker exec -it drupal_admin_ui_node test -e /var/www/.yarn-build-complete
 do
     sleep 20
 done

--- a/.docker/check-ready.sh
+++ b/.docker/check-ready.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-until docker exec -it drupal_admin_ui_drupal test -e ~/.drupal-installation-complete && docker exec -it drupal_admin_ui_node test -e /var/www/.yarn-build-complete
+until docker exec -it drupal_admin_ui_drupal test -e /var/www/.drupal-installation-complete && docker exec -it drupal_admin_ui_node test -e /var/www/.yarn-build-complete
 do
     sleep 20
 done

--- a/.docker/check-ready.sh
+++ b/.docker/check-ready.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-until docker exec -it drupal_admin_ui_drupal test -e /root/.drupal-installation-complete && docker exec -it drupal_admin_ui_node test -e /root/.yarn-build-complete
+until docker exec -it drupal_admin_ui_drupal test -e ~/.drupal-installation-complete && docker exec -it drupal_admin_ui_node test -e /root/.yarn-build-complete
 do
     sleep 20
 done

--- a/.docker/drupal/Dockerfile
+++ b/.docker/drupal/Dockerfile
@@ -1,25 +1,35 @@
 FROM alpine:3.8
 
-RUN apk add php sqlite composer git \
+ARG NGINX_UID
+ARG NGINX_GID
+ENV NGINX_UID "$NGINX_UID"
+ENV NGINX_GID "$NGINX_GID"
+
+RUN apk add shadow sudo && \
+    sed -i 's/^CREATE_MAIL_SPOOL=yes/CREATE_MAIL_SPOOL=no/' /etc/default/useradd && \
+    groupadd -g ${NGINX_GID} nginx && \
+    useradd -u ${NGINX_UID} -d /var/www -g ${NGINX_GID} nginx && \
+    sed -e 's/# %wheel ALL=(ALL) NOPASSWD: ALL/%wheel ALL=(ALL) NOPASSWD: ALL/g' -i /etc/sudoers && \
+    usermod -a -G wheel nginx && \
+    apk add php sqlite composer git \
     php7-pdo php7-sqlite3 php7-pdo_sqlite php7-gd php7-openssl php7-json \
     php7-mbstring php7-dom php7-session php7-xml php7-simplexml php7-tokenizer \
     php7-curl php7-xmlwriter php7-ctype php7-opcache php7-pdo_mysql mysql-client \
-    php-apache2 apache2 apache2-ctl
+    nginx php7-fpm && \
+    sed -i 's/;opcache.enable=1/opcache.enable=1/' /etc/php7/php.ini && \
+    mkdir -p /run/nginx && \
+    chown nginx:nginx /var/www
+
+ADD .docker/drupal/nginx-default.conf /etc/nginx/conf.d/default.conf
+
+USER nginx
 
 ADD demo /var/www/drupal
 ADD admin_ui_support /var/www/admin_ui_support
-
-RUN rm -rf /var/www/localhost && \
-    sed -i 's/\/var\/www\/localhost\/htdocs/\/var\/www\/drupal\/docroot/g' /etc/apache2/httpd.conf && \
-    sed -i 's/#LoadModule rewrite_module/LoadModule rewrite_module/g' /etc/apache2/httpd.conf && \
-    sed -i '/<Directory "\/var\/www\/drupal\/docroot">/,/<\/Directory>/s/AllowOverride None/AllowOverride All/' /etc/apache2/httpd.conf && \
-    sed -i 's/#ServerName www.example.com:80/ServerName 127.0.0.1:80/g' /etc/apache2/httpd.conf && \
-    sed -i 's/;opcache.enable=1/opcache.enable=1/' /etc/php7/php.ini && \
-    mkdir -p /run/apache2
 
 WORKDIR /var/www/drupal
 ENV PATH="/var/www/drupal/vendor/bin:${PATH}"
 
 EXPOSE 80
 
-ENTRYPOINT ["sh", "/root/.docker/drupal/setup.sh"]
+ENTRYPOINT ["sh", "/var/www/.docker/drupal/setup.sh"]

--- a/.docker/drupal/nginx-default.conf
+++ b/.docker/drupal/nginx-default.conf
@@ -63,6 +63,8 @@ server {
         fastcgi_param QUERY_STRING $query_string;
         fastcgi_intercept_errors on;
         fastcgi_pass 127.0.0.1:9000;
+        fastcgi_buffers 16 16k;
+        fastcgi_buffer_size 32k;
     }
 
     location ~ ^/sites/.*/files/styles/ {

--- a/.docker/drupal/nginx-default.conf
+++ b/.docker/drupal/nginx-default.conf
@@ -1,0 +1,83 @@
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    root /var/www/drupal/docroot;
+
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+
+    location ~ ^/vfancy {
+      allow all;
+      log_not_found off;
+      access_log off;
+    }
+
+    location ~ \..*/.*\.php$ {
+        return 403;
+    }
+
+    location ~ ^/sites/.*/private/ {
+        return 403;
+    }
+
+    # Block access to scripts in site files directory
+    location ~ ^/sites/[^/]+/files/.*\.php$ {
+        deny all;
+    }
+
+    # Allow "Well-Known URIs" as per RFC 5785
+    location ~* ^/.well-known/ {
+        allow all;
+    }
+
+    # Block access to "hidden" files and directories whose names begin with a
+    # period. This includes directories used by version control systems such
+    # as Subversion or Git to store control files.
+    location ~ (^|/)\. {
+        return 403;
+    }
+
+    location / {
+        try_files $uri /index.php?$query_string;
+    }
+
+    location @rewrite {
+        rewrite ^/(.*)$ /index.php?q=$1;
+    }
+
+    location ~ '\.php$|^/update.php' {
+        fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
+        include fastcgi_params;
+        # Block httpoxy attacks. See https://httpoxy.org/.
+        fastcgi_param HTTP_PROXY "";
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+        fastcgi_param QUERY_STRING $query_string;
+        fastcgi_intercept_errors on;
+        fastcgi_pass 127.0.0.1:9000;
+    }
+
+    location ~ ^/sites/.*/files/styles/ {
+        try_files $uri @rewrite;
+    }
+
+    # Handle private files through Drupal. Private file's path can come
+    # with a language prefix.
+    location ~ ^(/[a-z\-]+)?/system/files/ {
+        try_files $uri /index.php?$query_string;
+    }
+
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
+        try_files $uri @rewrite;
+        expires max;
+        log_not_found off;
+    }
+}

--- a/.docker/drupal/setup.sh
+++ b/.docker/drupal/setup.sh
@@ -1,31 +1,45 @@
 #!/bin/sh
 
-rm -f /root/.drupal-installation-complete
+rm -f ~/.drupal-installation-complete
+sudo chown -R nginx:nginx /var/www/.composer/cache
 
 # If settings.php doesn't exist, create it and install Drupal
-if [ ! -f /var/www/drupal/docroot/sites/default/settings.php ]; then
+if [ ! -f  docroot/sites/default/settings.php ]; then
     echo "settings.php not detected - installing Drupal (this may take some time, wait for a one-time login link to appear!)"
-    rm -rf reports config composer.json composer.lock vendor docroot/.ht.router.php docroot/core docroot/modules docroot/sites/simpletest docroot/sites/default/files docroot/sites/default/settings.php docroot/sites/default/services.yml
-    cp /var/www/drupal/docroot/sites/default/default.settings.php /var/www/drupal/docroot/sites/default/settings.php
+    rm -rf \
+      composer.json \
+      composer.lock \
+      config \
+      docroot/.ht.router.php \
+      docroot/core \
+      docroot/modules \
+      docroot/sites/default/files \
+      docroot/sites/default/settings.php \
+      docroot/sites/default/services.yml \
+      docroot/sites/simpletest \
+      docroot/vfancy \
+      reports \
+      vendor
+    chmod 755 docroot/sites/default
+    cp docroot/sites/default/default.settings.php docroot/sites/default/settings.php
     echo "\$settings['trusted_host_patterns'] = [
   '^drupal\$',
   '^127\.0\.0\.1\$',
-];" >> /var/www/drupal/docroot/sites/default/settings.php
+];" >> docroot/sites/default/settings.php
     cp templates/composer.json composer.json
     cp templates/composer.lock composer.lock
     cp templates/.ht.router.php docroot/.ht.router.php
-    echo "\$config_directories['sync'] = '../config/sync';" >> /var/www/drupal/docroot/sites/default/settings.php
+    echo "\$config_directories['sync'] = '../config/sync';" >> docroot/sites/default/settings.php
     mkdir docroot/sites/default/files docroot/sites/simpletest reports
-    chown apache:apache docroot/sites/default/files docroot/sites/simpletest reports
     chmod 777 docroot/sites/default/files
     composer config repositories.repo-name path "/var/www/admin_ui_support"
     composer require justafish/drupal-admin-ui-support:dev-master
     composer install
-    chmod +x /var/www/drupal/docroot/core/scripts/drupal
     drush site:install demo_umami -y --db-url=mysql://drupal:drupal@mysql:3306/drupal --sites-subdir=default
     drush en -y jsonapi admin_ui_support admin_ui_widget_example
     drush config:set -y system.logging error_level verbose
-    rm -rf docroot/sites/default/files/styles
+    rm -rf docroot/vfancy
+    ln -s /var/www/admin-ui/build/ docroot/vfancy
 fi
 
 echo "##############################################################################################
@@ -34,6 +48,7 @@ echo "##########################################################################
 ##############################################################################################"
 
 # Create a file to indicate installation has finished
-touch /root/.drupal-installation-complete
+touch ~/.drupal-installation-complete
 
-apachectl start -DFOREGROUND
+sudo php-fpm7
+sudo nginx -g 'daemon off;'

--- a/.docker/node/Dockerfile
+++ b/.docker/node/Dockerfile
@@ -1,10 +1,26 @@
 FROM node:10-alpine
 
-RUN apk add chromium chromium-chromedriver
+ARG NODE_UID
+ARG NODE_GID
+ENV NODE_UID "$NODE_UID"
+ENV NODE_GID "$NODE_GID"
 
-RUN mkdir -p /root/drupal-admin-ui
-WORKDIR /root/drupal-admin-ui
+RUN apk add shadow sudo chromium chromium-chromedriver
+
+RUN mkdir -p /var/www && \
+    deluser node && \
+    sed -i 's/^CREATE_MAIL_SPOOL=yes/CREATE_MAIL_SPOOL=no/' /etc/default/useradd && \
+    groupadd -g ${NODE_GID} node && \
+    useradd -u ${NODE_UID} -d /var/www -g ${NODE_GID} node && \
+    sed -e 's/# %wheel ALL=(ALL) NOPASSWD: ALL/%wheel ALL=(ALL) NOPASSWD: ALL/g' -i /etc/sudoers && \
+    usermod -a -G wheel node && \
+    chown node:node /var/www
+
+USER node
+
+RUN mkdir -p /var/www/drupal-admin-ui
+WORKDIR /var/www/drupal-admin-ui
 
 EXPOSE 3000
 
-ENTRYPOINT ["sh", "/root/drupal-admin-ui/.docker/node/setup.sh"]
+ENTRYPOINT ["sh", "/var/www/drupal-admin-ui/.docker/node/setup.sh"]

--- a/.docker/node/setup.sh
+++ b/.docker/node/setup.sh
@@ -1,16 +1,17 @@
 #!/bin/sh
 
-rm -f /root/.yarn-build-complete
+rm -f /var/www/.yarn-build-complete
 
-if [ ! -f /root/drupal-admin-ui/packages/admin-ui/.env.local ]; then
+if [ ! -f /var/www/drupal-admin-ui/packages/admin-ui/.env.local ]; then
     cp packages/admin-ui/.env packages/admin-ui/.env.local
     chmod 666 packages/admin-ui/.env.local
 fi
 
+sudo chown -R node:node /var/www/.cache
 yarn install
 yarn workspace admin-ui build
 
 # Create a file to indicate build has finished
-touch /root/.yarn-build-complete
+touch /var/www/.yarn-build-complete
 
 yarn workspace admin-ui start

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@ demo/docroot/sites/simpletest
 demo/docroot/sites/default/files/
 demo/docroot/sites/default/settings.php
 demo/docroot/sites/default/services.yml
-demo/docroot/vfancy/
+demo/docroot/vfancy

--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ or `docker exec -it -e REACT_APP_DRUPAL_BASE_URL=http://drupal -e NIGHTWATCH_LOG
 - When you're finished, restore the regular build if you want to browse the compiled version in your browser with `docker exec -it drupal_admin_ui_node yarn workspace admin-ui build`.
 This will also be restored when you restart your containers.
 
+### Drupal/Phpunit tests
+
+To execute the drupal/phpunit tests, use `docker exec -u $(id -u):$(id -g) -it drupal_admin_ui_drupal composer test`
+
 ### Local Installation
 
 #### Requirements

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Move it to ~/.cache/yarn (see https://yarnpkg.com/lang/en/docs/cli/cache/ for in
 ```
 git clone git@github.com:jsdrupal/drupal-admin-ui.git
 cd drupal-admin-ui
-UID=$(id -u) GID=$(id -g) docker-compose buil
+uid=$(id -u) gid=$(id -g) docker-compose buil
 docker-compose up
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Move it to ~/.cache/yarn (see https://yarnpkg.com/lang/en/docs/cli/cache/ for in
 ```
 git clone git@github.com:jsdrupal/drupal-admin-ui.git
 cd drupal-admin-ui
-uid=$(id -u) gid=$(id -g) docker-compose buil
+uid=$(id -u) gid=$(id -g) docker-compose build
 docker-compose up
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Move it to ~/.cache/yarn (see https://yarnpkg.com/lang/en/docs/cli/cache/ for in
 ```
 git clone git@github.com:jsdrupal/drupal-admin-ui.git
 cd drupal-admin-ui
+UID=$(id -u) GID=$(id -g) docker-compose buil
 docker-compose up
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,8 @@ services:
       context: .
       dockerfile: ./.docker/drupal/Dockerfile
       args:
-        - NGINX_UID=${UID}
-        - NGINX_GID=${GID}
+        - NGINX_UID=${uid}
+        - NGINX_GID=${gid}
     ports:
       - 80:80
     volumes:
@@ -47,8 +47,8 @@ services:
       context: .
       dockerfile: ./.docker/node/Dockerfile
       args:
-        - NODE_UID=${UID}
-        - NODE_GID=${GID}
+        - NODE_UID=${uid}
+        - NODE_GID=${gid}
     ports:
       - 3000:3000
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,14 +23,17 @@ services:
     build:
       context: .
       dockerfile: ./.docker/drupal/Dockerfile
+      args:
+        - NGINX_UID=${UID}
+        - NGINX_GID=${GID}
     ports:
       - 80:80
     volumes:
-      - ~/.composer/cache:/root/.composer/cache:cached
-      - ./.docker:/root/.docker:cached
+      - ~/.composer/cache:/var/www/.composer/cache:cached
+      - ./.docker:/var/www/.docker:cached
       - ./demo:/var/www/drupal:cached
       - ./admin_ui_support:/var/www/admin_ui_support:cached
-      - ./packages/admin-ui/build:/var/www/drupal/docroot/vfancy:cached
+      - ./packages/admin-ui:/var/www/admin-ui:cached
 
   node:
     container_name: drupal_admin_ui_node
@@ -43,15 +46,14 @@ services:
     build:
       context: .
       dockerfile: ./.docker/node/Dockerfile
+      args:
+        - NODE_UID=${UID}
+        - NODE_GID=${GID}
     ports:
       - 3000:3000
     volumes:
-      - .:/root/drupal-admin-ui:cached
-      - ~/.cache/yarn:/root/.cache/yarn:cached
-      - /root/drupal-admin-ui/node_modules
-      - /root/drupal-admin-ui/packages/admin-ui/node_modules
-      - /root/drupal-admin-ui/packages/components/node_modules
-      - /root/drupal-admin-ui/packages/extension-points/node_modules
+      - .:/var/www/drupal-admin-ui:cached
+      - ~/.cache/yarn:/var/www/.cache/yarn:cached
 
 volumes:
   db_data:


### PR DESCRIPTION
When you use `docker exec` or `docker run` it executes the command as a root user. Therefore add the parameters to the composer test call as otherwise it fails.