### PR TITLE
[#643] Correct the margins applied to the formControls for admin/content

### DIFF
--- a/packages/admin-ui/src/components/05_pages/Content/Content.js
+++ b/packages/admin-ui/src/components/05_pages/Content/Content.js
@@ -52,7 +52,7 @@ const styles = {
     max-width: 19rem;
   `,
   formControl: css`
-    margin: 0.5rem;
+    margin: 1rem 0 0.5rem 0.5rem;
     min-width: 8rem;
     max-width: 19rem;
   `,


### PR DESCRIPTION
## Issue

https://github.com/jsdrupal/drupal-admin-ui/issues/643

## Screenshot / UI changes
![image](https://user-images.githubusercontent.com/429100/54100824-8bfa9280-4414-11e9-8b49-68817ff09975.png)

## Testing instructions

Visit /admin/content and observe the alignment of the form controls after the text field. The select fields are not vertically aligned. This fix applies margin to the top and bottom of those fields and removes margin on the right so the spacing between the fields is even.




