### PR TITLE
[#645] Fix typo, console.err should be console.error

### DIFF
--- a/packages/admin-ui/src/index.js
+++ b/packages/admin-ui/src/index.js
@@ -16,7 +16,7 @@ if (process.env.NODE_ENV !== 'production' && process.env.REACT_APP_AXE) {
 // This happens outsite of React and before the application starts.
 api('admin_ui_routes')
   .catch(err => {
-    console.err(err); // eslint-disable-line no-console
+    console.error(err); // eslint-disable-line no-console
     return [];
   })
   .then(({ routes }) => {


### PR DESCRIPTION
## Issue

https://github.com/jsdrupal/drupal-admin-ui/issues/645

## Testing instructions

You can only see this error when the api is not available or has not yet been set up. When setting up the project for the first time I noticed that `drupal_admin_ui_node` reported that the local URL was available and I command clicked it. This loaded the page before Drupal was fully installed resulting in an error that `console.err is not a function`. Once Drupal had finished installing the error disappeared because Drupal was able to fetch It's routes and start the react app.