### PR TITLE
Revert "fix(package): update react-redux to version 7.0.0"

### DIFF
--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -38,7 +38,7 @@
     "react-dom": "^16.6.3",
     "react-emotion": "^9.2.5",
     "react-jss": "^8.4.0",
-    "react-redux": "^7.0.0",
+    "react-redux": "^5.0.7",
     "react-redux-loading-bar": "^4.1.0",
     "react-router": "^4.3.1",
     "react-router-dom": "^4.2.2",


### PR DESCRIPTION
This reverts commit d87a6bdd7c53d4165dbc6af91f3de36e024d0f5f.

This commit was introduced in https://github.com/jsdrupal/drupal-admin-ui/pull/693 by Greenkeeper. The update to react-redux causes the build process to work and `yarn workspace admin-ui build`, `yarn workspace admin-ui start` ends up in an unusable application.

Reverting to version `^5.0.7` fixes the problem.

