### PR TITLE
[#691] First pass at adding a generic <Label> component

### DIFF
--- a/packages/components/src/Components/FormElements/FormElements.stories.js
+++ b/packages/components/src/Components/FormElements/FormElements.stories.js
@@ -1,0 +1,19 @@
+import React from 'react';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { boolean, object, text } from '@storybook/addon-knobs/react';
+
+import Label from './Label';
+
+storiesOf('FormElements/Label', module).addWithJSX('Default', () => (
+  <Label
+    fieldName="ControlOne"
+    labelFor="asdf"
+    error={boolean('Label: error', false)}
+    required={boolean('Label: required', false)}
+    htmlAttributes={object('Label: htmlAttributes', { 'data-test': 'test' })}
+  >
+    {text('Label: label', 'Field label')}
+  </Label>
+));

--- a/packages/components/src/Components/FormElements/FormElements.stories.js
+++ b/packages/components/src/Components/FormElements/FormElements.stories.js
@@ -9,7 +9,7 @@ import Label from './Label';
 storiesOf('FormElements/Label', module).addWithJSX('Default', () => (
   <Label
     fieldName="ControlOne"
-    labelFor="asdf"
+    htmlFor={text('Label: htmlFor', 'test-label-for')}
     error={boolean('Label: error', false)}
     required={boolean('Label: required', false)}
     htmlAttributes={object('Label: htmlAttributes', { 'data-test': 'test' })}

--- a/packages/components/src/Components/FormElements/Label.js
+++ b/packages/components/src/Components/FormElements/Label.js
@@ -1,0 +1,83 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css } from 'emotion';
+
+import colors from '../../Utils/colors';
+
+const styles = {
+  label: css`
+    color: ${colors.text};
+  `,
+  labelRequired: css`
+    :after {
+      content: ' *';
+      color: ${colors.maximumRed};
+    }
+  `,
+  labelWithError: css`
+    color: ${colors.maximumRed};
+  `,
+};
+
+/**
+ * Renders an HTML <label> element.
+ *
+ * Example:
+ *
+ * @code
+ * <Label htmlFor="title" required={true}>Article title</Label>
+ * @endcode
+ */
+const Label = ({ children, htmlFor, error, required, htmlAttributes }) => {
+  const classes = [styles.label];
+  if (required) {
+    classes.push(styles.labelRequired);
+  }
+  if (error) {
+    classes.push(styles.labelWithError);
+  }
+
+  return (
+    <label
+      htmlFor={htmlFor}
+      className={css`
+        ${classes}
+      `}
+      {...htmlAttributes}
+    >
+      {children}
+    </label>
+  );
+};
+
+Label.propTypes = {
+  /** Content contained within the label element. */
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]).isRequired,
+
+  /** true if the label relates to an element with an error. */
+  error: PropTypes.bool,
+
+  /** Any additional HTML properties to add to the label element. */
+  htmlAttributes: PropTypes.objectOf([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.bool,
+  ]),
+
+  /** Content of the html "for" attribute to use for this label. */
+  htmlFor: PropTypes.string.isRequired,
+
+  /** True if this label relates to an element that is required. */
+  required: PropTypes.bool,
+};
+
+Label.defaultProps = {
+  error: false,
+  htmlAttributes: {},
+  required: false,
+};
+
+export default Label;

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -1,3 +1,4 @@
 export { default as AdminUIButton } from './Components/Button/Button';
 export { default as colors } from './Utils/colors';
+export { default as Label } from './Components/FormElements/Label';
 export { default as typography } from './Utils/typography';


### PR DESCRIPTION
## Issue

https://github.com/jsdrupal/drupal-admin-ui/issues/691

Add a generic `<Label/>` component for use on forms.

There's not really anything to see yet since the component isn't used anywhere. You can run storybook to see it in action though.

This is probably also not complete as this is just a first pass at figuring out how to create one of these generic form components. It's also my first go at creating a component for this project so feel free to suggest alternative approaches to anything. :)

Example use:

```jsx
<Label htmlFor="username" required={true} htmlAttributes={['data-username' => 'snorfblat']}>Username:</Label>
```

In order to allow someone to pass along generic HTML attributes to the component I've added an `htmlAttributes` prop. With the idea that you populate that with any attributes as key/value pairs, and they get spread to the component. e.g. `<Label htmlFor="username" htmlAttribues={{'data-username': 'snorfblat'}}>Username:</Label>`. And alternative option would be to just spread all non-used props into the `<label>` element. I personally like using `htmlAttributes` as it gives us a property we can document. But open to whatever.

I think whatever we decide here should be the pattern we use for the remaining generic components.

Anyway, here's a start at least.