### PR TITLE
738: Removed button component from elements in the Drawer navigation

### DIFF
--- a/packages/admin-ui/src/components/06_wrappers/Default/Default.js
+++ b/packages/admin-ui/src/components/06_wrappers/Default/Default.js
@@ -90,7 +90,6 @@ class Default extends React.Component {
             <ListItem
               key={menuLink.url.replace(/\//g, '-')}
               component="li"
-              button
             >
               <Link to={menuLink.url} className={styles.menuLink} role="button">
                 {iconMap[menuLink.url] ? (


### PR DESCRIPTION
## Issue
https://github.com/jsdrupal/drupal-admin-ui/issues/738 

## Screenshot / UI changes
The interaction events on hover, click and focus no longer apply to the `<li>` and so the UI looks the same as it does in its default state. However the outline of the focus indicator persists (yay).

![download (40)](https://user-images.githubusercontent.com/2318561/57931614-c834ee00-78b0-11e9-8623-f72104f4c8e2.png)

## Testing instructions
- Check if the interface works as it did before;
- With a keyboard and with the 'tab' key, navigate through the Drawer navigation and check if you need to press the 'tab' key once to get to the next Drawer item.